### PR TITLE
chore: bump lucide-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "dependencies": {
     "jspdf": "^3.0.1",
-    "lucide-react": "^0.263.1",
+    "lucide-react": "^0.279.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hot-toast": "^2.4.0",


### PR DESCRIPTION
## Summary
- bump lucide-react version to ^0.279.0 so the Barcode icon is available

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lucide-react)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm start` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6777ffc832dadf96e6e6531b715