### PR TITLE
fix: remove stray SalesModule definition

### DIFF
--- a/src/modules/sales/SalesModule.jsx
+++ b/src/modules/sales/SalesModule.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Search, ShoppingCart, CreditCard } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
-import { useResponsive, getResponsiveStyles, ProductGrid, ResponsiveModal } from '../../components/ResponsiveComponents';
-
 
 const SalesModule = () => {
   const { globalProducts, processSale, customers, appSettings, addCredit } = useApp();
@@ -14,32 +12,9 @@ const SalesModule = () => {
   const [paymentMethod, setPaymentMethod] = useState('cash');
   const [amountReceived, setAmountReceived] = useState('');
   const [quickMode, setQuickMode] = useState(true); // Mode rapide par défaut
-  
+
   const products = globalProducts;
   const isDark = appSettings.darkMode;
-  const SalesModule = () => {
-  const { deviceType, isMobile } = useResponsive();
-  const styles = getResponsiveStyles(deviceType, isDark);
-  
-  return (
-    <div style={{
-      display: 'grid',
-      gridTemplateColumns: isMobile ? '1fr' : deviceType === 'tablet' ? '1fr 300px' : '1fr 400px',
-      gap: '20px',
-      padding: styles.container.padding
-    }}>
-      {/* Section produits avec grille responsive */}
-      <ProductGrid 
-        products={filteredProducts}
-        onProductClick={addToCart}
-        isDark={isDark}
-      />
-      
-      {/* Panier - drawer mobile ou sidebar */}
-      {/* Code adapté selon deviceType */}
-    </div>
-  );
-};
 
   // Montants fréquents pour les paiements rapides
   const frequentAmounts = [500, 1000, 2000, 5000, 10000, 20000];


### PR DESCRIPTION
## Summary
- remove stray nested SalesModule component
- clean up unused imports in SalesModule module

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc48656b4832d944e908e9063178e