### PR TITLE
chore: update lucide-react for Barcode icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "dependencies": {
     "jspdf": "^3.0.1",
-    "lucide-react": "^0.279.0",
+    "lucide-react": "^0.344.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hot-toast": "^2.4.0",


### PR DESCRIPTION
## Summary
- upgrade lucide-react dependency to version providing the Barcode icon

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lucide-react)*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd01395a8832d85031ff908b74eba