### PR TITLE
feat: add employees and returns modules

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,8 +8,10 @@ import CashRegisterModule from './modules/cash/CashRegisterModule';
 import CreditManagementModule from './modules/credits/CreditManagementModule';
 import DashboardModule from './modules/dashboard/DashboardModule';
 import ReportsModule from './modules/reports/ReportsModule';
+import EmployeesModule from './modules/employees/EmployeesModule';
+import ReturnsModule from './modules/returns/ReturnsModule';
 import { MobileNavigation, useResponsive } from './components/ResponsiveComponents';
-import { ShoppingCart, Package, Users, Home, BarChart3, Settings, Calculator, CreditCard } from 'lucide-react';
+import { ShoppingCart, Package, Users, Home, BarChart3, Settings, Calculator, CreditCard, UserCog, RotateCcw } from 'lucide-react';
 
 // Composant principal avec le Provider
 function App() {
@@ -148,6 +150,10 @@ function AppContent() {
         return <CashRegisterModule />;
       case 'credits':
         return <CreditManagementModule />;
+      case 'employees':
+        return <EmployeesModule />;
+      case 'returns':
+        return <ReturnsModule />;
       default:
         return <DashboardModule />;
     }
@@ -321,7 +327,29 @@ function AppContent() {
             <Users size={18} />
             Clients
           </button>
-          
+
+          <button
+            style={{
+              ...styles.navButton,
+              ...(activeModule === 'employees' ? styles.navButtonActive : {})
+            }}
+            onClick={() => setActiveModule('employees')}
+          >
+            <UserCog size={18} />
+            Employés
+          </button>
+
+          <button
+            style={{
+              ...styles.navButton,
+              ...(activeModule === 'returns' ? styles.navButtonActive : {})
+            }}
+            onClick={() => setActiveModule('returns')}
+          >
+            <RotateCcw size={18} />
+            Retours
+          </button>
+
           <button
             style={{
               ...styles.navButton,

--- a/src/components/ResponsiveComponents.js
+++ b/src/components/ResponsiveComponents.js
@@ -211,7 +211,9 @@ export const MobileNavigation = ({ activeModule, setActiveModule, isDark }) => {
     { id: 'sales', icon: '🛒', label: 'Ventes' },
     { id: 'stocks', icon: '📦', label: 'Stocks' },
     { id: 'credits', icon: '💳', label: 'Crédits' },
-    { id: 'cash', icon: '🧮', label: 'Caisse' }
+    { id: 'cash', icon: '🧮', label: 'Caisse' },
+    { id: 'employees', icon: '👥', label: 'Employés' },
+    { id: 'returns', icon: '↩️', label: 'Retours' }
   ];
 
   return (

--- a/src/modules/employees/EmployeeForm.jsx
+++ b/src/modules/employees/EmployeeForm.jsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+
+const EmployeeForm = () => {
+  const { employees, setEmployees, appSettings } = useApp();
+  const [form, setForm] = useState({ name: '', role: '', phone: '' });
+  const isDark = appSettings.darkMode;
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const addEmployee = () => {
+    if (!form.name.trim()) return;
+    const newEmployee = {
+      id: Date.now(),
+      name: form.name.trim(),
+      role: form.role.trim(),
+      phone: form.phone.trim(),
+      shifts: []
+    };
+    setEmployees([...(employees || []), newEmployee]);
+    setForm({ name: '', role: '', phone: '' });
+  };
+
+  const styles = {
+    form: {
+      display: 'flex',
+      gap: '10px',
+      marginBottom: '20px',
+      flexWrap: 'wrap'
+    },
+    input: {
+      flex: '1 1 150px',
+      padding: '8px',
+      borderRadius: '6px',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      background: isDark ? '#374151' : 'white',
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    addButton: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '8px 12px',
+      background: '#3182ce',
+      color: 'white',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer'
+    }
+  };
+
+  return (
+    <div style={styles.form}>
+      <input
+        name="name"
+        placeholder="Nom"
+        value={form.name}
+        onChange={handleChange}
+        style={styles.input}
+      />
+      <input
+        name="role"
+        placeholder="Rôle"
+        value={form.role}
+        onChange={handleChange}
+        style={styles.input}
+      />
+      <input
+        name="phone"
+        placeholder="Téléphone"
+        value={form.phone}
+        onChange={handleChange}
+        style={styles.input}
+      />
+      <button onClick={addEmployee} style={styles.addButton}>
+        <Plus size={16} /> Ajouter
+      </button>
+    </div>
+  );
+};
+
+export default EmployeeForm;

--- a/src/modules/employees/EmployeeList.jsx
+++ b/src/modules/employees/EmployeeList.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Trash2 } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+
+const EmployeeList = () => {
+  const { employees, setEmployees, appSettings } = useApp();
+  const isDark = appSettings.darkMode;
+
+  const removeEmployee = (id) => {
+    if (window.confirm('Supprimer cet employé ?')) {
+      setEmployees((employees || []).filter(e => e.id !== id));
+    }
+  };
+
+  const styles = {
+    table: {
+      width: '100%',
+      borderCollapse: 'collapse',
+      background: isDark ? '#2d3748' : 'white'
+    },
+    th: {
+      textAlign: 'left',
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    td: {
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    deleteButton: {
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+      color: '#ef4444'
+    }
+  };
+
+  const list = employees || [];
+
+  return (
+    <table style={styles.table}>
+      <thead>
+        <tr>
+          <th style={styles.th}>Nom</th>
+          <th style={styles.th}>Rôle</th>
+          <th style={styles.th}>Téléphone</th>
+          <th style={styles.th}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {list.map(emp => (
+          <tr key={emp.id}>
+            <td style={styles.td}>{emp.name}</td>
+            <td style={styles.td}>{emp.role}</td>
+            <td style={styles.td}>{emp.phone}</td>
+            <td style={styles.td}>
+              <button onClick={() => removeEmployee(emp.id)} style={styles.deleteButton}>
+                <Trash2 size={16} />
+              </button>
+            </td>
+          </tr>
+        ))}
+        {list.length === 0 && (
+          <tr>
+            <td style={styles.td} colSpan="4">Aucun employé</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default EmployeeList;

--- a/src/modules/employees/EmployeesModule.jsx
+++ b/src/modules/employees/EmployeesModule.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Users, UserPlus, Clock } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+import EmployeeForm from './EmployeeForm';
+import EmployeeList from './EmployeeList';
+import ShiftManagement from './ShiftManagement';
+
+const EmployeesModule = () => {
+  const { appSettings } = useApp();
+  const [activeTab, setActiveTab] = useState('list');
+  const isDark = appSettings.darkMode;
+
+  const styles = {
+    container: {
+      padding: '20px',
+      background: isDark ? '#1a202c' : '#f7fafc',
+      minHeight: 'calc(100vh - 120px)'
+    },
+    tabs: {
+      display: 'flex',
+      gap: '10px',
+      marginBottom: '20px',
+      background: isDark ? '#2d3748' : 'white',
+      padding: '8px',
+      borderRadius: '8px'
+    },
+    tabButton: {
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '6px',
+      padding: '8px',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer',
+      background: 'transparent',
+      color: isDark ? '#a0aec0' : '#64748b',
+      fontWeight: '600'
+    },
+    activeTab: {
+      background: isDark ? '#4a5568' : '#e2e8f0',
+      color: isDark ? '#f7fafc' : '#1a202c'
+    }
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.tabs}>
+        <button
+          style={{ ...styles.tabButton, ...(activeTab === 'list' ? styles.activeTab : {}) }}
+          onClick={() => setActiveTab('list')}
+        >
+          <Users size={18} /> Liste
+        </button>
+        <button
+          style={{ ...styles.tabButton, ...(activeTab === 'add' ? styles.activeTab : {}) }}
+          onClick={() => setActiveTab('add')}
+        >
+          <UserPlus size={18} /> Ajouter
+        </button>
+        <button
+          style={{ ...styles.tabButton, ...(activeTab === 'shifts' ? styles.activeTab : {}) }}
+          onClick={() => setActiveTab('shifts')}
+        >
+          <Clock size={18} /> Horaires
+        </button>
+      </div>
+
+      {activeTab === 'list' && <EmployeeList />}
+      {activeTab === 'add' && <EmployeeForm />}
+      {activeTab === 'shifts' && <ShiftManagement />}
+    </div>
+  );
+};
+
+export default EmployeesModule;

--- a/src/modules/employees/ShiftManagement.jsx
+++ b/src/modules/employees/ShiftManagement.jsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+
+const ShiftManagement = () => {
+  const { employees, setEmployees, appSettings } = useApp();
+  const [shift, setShift] = useState({ employeeId: '', date: '', start: '', end: '' });
+  const isDark = appSettings.darkMode;
+
+  const handleChange = (e) => {
+    setShift({ ...shift, [e.target.name]: e.target.value });
+  };
+
+  const addShift = () => {
+    const { employeeId, date, start, end } = shift;
+    if (!employeeId || !date || !start || !end) return;
+    setEmployees((employees || []).map(emp =>
+      emp.id === parseInt(employeeId)
+        ? { ...emp, shifts: [...(emp.shifts || []), { id: Date.now(), date, start, end }] }
+        : emp
+    ));
+    setShift({ employeeId: '', date: '', start: '', end: '' });
+  };
+
+  const removeShift = (empId, shiftId) => {
+    setEmployees((employees || []).map(emp =>
+      emp.id === empId
+        ? { ...emp, shifts: (emp.shifts || []).filter(s => s.id !== shiftId) }
+        : emp
+    ));
+  };
+
+  const styles = {
+    form: {
+      display: 'flex',
+      gap: '10px',
+      marginBottom: '20px',
+      flexWrap: 'wrap'
+    },
+    input: {
+      flex: '1 1 150px',
+      padding: '8px',
+      borderRadius: '6px',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      background: isDark ? '#374151' : 'white',
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    addButton: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '8px 12px',
+      background: '#3182ce',
+      color: 'white',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer'
+    },
+    table: {
+      width: '100%',
+      borderCollapse: 'collapse',
+      marginTop: '10px',
+      background: isDark ? '#2d3748' : 'white'
+    },
+    th: {
+      textAlign: 'left',
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    td: {
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    deleteButton: {
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+      color: '#ef4444'
+    }
+  };
+
+  const list = employees || [];
+
+  return (
+    <div>
+      <div style={styles.form}>
+        <select name="employeeId" value={shift.employeeId} onChange={handleChange} style={styles.input}>
+          <option value="">Employé</option>
+          {list.map(emp => (
+            <option key={emp.id} value={emp.id}>{emp.name}</option>
+          ))}
+        </select>
+        <input type="date" name="date" value={shift.date} onChange={handleChange} style={styles.input} />
+        <input type="time" name="start" value={shift.start} onChange={handleChange} style={styles.input} />
+        <input type="time" name="end" value={shift.end} onChange={handleChange} style={styles.input} />
+        <button onClick={addShift} style={styles.addButton}>
+          <Plus size={16} /> Ajouter
+        </button>
+      </div>
+
+      {list.map(emp => (
+        <div key={emp.id} style={{ marginBottom: '20px' }}>
+          <h3 style={{ margin: '10px 0', color: isDark ? '#f7fafc' : '#2d3748' }}>{emp.name}</h3>
+          <table style={styles.table}>
+            <thead>
+              <tr>
+                <th style={styles.th}>Date</th>
+                <th style={styles.th}>Début</th>
+                <th style={styles.th}>Fin</th>
+                <th style={styles.th}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(emp.shifts || []).map(s => (
+                <tr key={s.id}>
+                  <td style={styles.td}>{s.date}</td>
+                  <td style={styles.td}>{s.start}</td>
+                  <td style={styles.td}>{s.end}</td>
+                  <td style={styles.td}>
+                    <button onClick={() => removeShift(emp.id, s.id)} style={styles.deleteButton}>
+                      <Trash2 size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {(emp.shifts || []).length === 0 && (
+                <tr>
+                  <td style={styles.td} colSpan="4">Aucun horaire</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ShiftManagement;

--- a/src/modules/returns/ReturnForm.jsx
+++ b/src/modules/returns/ReturnForm.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+
+const ReturnForm = () => {
+  const { globalProducts, processReturn, appSettings } = useApp();
+  const [form, setForm] = useState({ productId: '', quantity: '', reason: '' });
+  const isDark = appSettings.darkMode;
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = () => {
+    const quantity = parseInt(form.quantity, 10);
+    if (!form.productId || !quantity) return;
+    processReturn(parseInt(form.productId, 10), quantity, form.reason.trim());
+    setForm({ productId: '', quantity: '', reason: '' });
+  };
+
+  const styles = {
+    form: {
+      display: 'flex',
+      gap: '10px',
+      marginBottom: '20px',
+      flexWrap: 'wrap'
+    },
+    input: {
+      flex: '1 1 150px',
+      padding: '8px',
+      borderRadius: '6px',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      background: isDark ? '#374151' : 'white',
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    addButton: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '8px 12px',
+      background: '#3182ce',
+      color: 'white',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer'
+    }
+  };
+
+  return (
+    <div style={styles.form}>
+      <select name="productId" value={form.productId} onChange={handleChange} style={styles.input}>
+        <option value="">Produit</option>
+        {(globalProducts || []).map(p => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+      <input
+        name="quantity"
+        type="number"
+        placeholder="Quantité"
+        value={form.quantity}
+        onChange={handleChange}
+        style={styles.input}
+      />
+      <input
+        name="reason"
+        placeholder="Raison"
+        value={form.reason}
+        onChange={handleChange}
+        style={styles.input}
+      />
+      <button onClick={submit} style={styles.addButton}>
+        <Plus size={16} /> Enregistrer
+      </button>
+    </div>
+  );
+};
+
+export default ReturnForm;

--- a/src/modules/returns/ReturnHistory.jsx
+++ b/src/modules/returns/ReturnHistory.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useApp } from '../../contexts/AppContext';
+
+const ReturnHistory = () => {
+  const { returnsHistory, appSettings } = useApp();
+  const isDark = appSettings.darkMode;
+  const list = returnsHistory || [];
+
+  const styles = {
+    table: {
+      width: '100%',
+      borderCollapse: 'collapse',
+      background: isDark ? '#2d3748' : 'white'
+    },
+    th: {
+      textAlign: 'left',
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    td: {
+      padding: '8px',
+      borderBottom: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      color: isDark ? '#f7fafc' : '#2d3748'
+    }
+  };
+
+  return (
+    <table style={styles.table}>
+      <thead>
+        <tr>
+          <th style={styles.th}>Date</th>
+          <th style={styles.th}>Produit</th>
+          <th style={styles.th}>Quantité</th>
+          <th style={styles.th}>Raison</th>
+        </tr>
+      </thead>
+      <tbody>
+        {list.map(r => (
+          <tr key={r.id}>
+            <td style={styles.td}>{new Date(r.date).toLocaleString()}</td>
+            <td style={styles.td}>{r.productName}</td>
+            <td style={styles.td}>{r.quantity}</td>
+            <td style={styles.td}>{r.reason}</td>
+          </tr>
+        ))}
+        {list.length === 0 && (
+          <tr>
+            <td style={styles.td} colSpan="4">Aucun retour enregistré</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default ReturnHistory;

--- a/src/modules/returns/ReturnsModule.jsx
+++ b/src/modules/returns/ReturnsModule.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { CornerUpLeft, History } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+import ReturnForm from './ReturnForm';
+import ReturnHistory from './ReturnHistory';
+
+const ReturnsModule = () => {
+  const { appSettings } = useApp();
+  const [activeTab, setActiveTab] = useState('form');
+  const isDark = appSettings.darkMode;
+
+  const styles = {
+    container: {
+      padding: '20px',
+      background: isDark ? '#1a202c' : '#f7fafc',
+      minHeight: 'calc(100vh - 120px)'
+    },
+    tabs: {
+      display: 'flex',
+      gap: '10px',
+      marginBottom: '20px',
+      background: isDark ? '#2d3748' : 'white',
+      padding: '8px',
+      borderRadius: '8px'
+    },
+    tabButton: {
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '6px',
+      padding: '8px',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer',
+      background: 'transparent',
+      color: isDark ? '#a0aec0' : '#64748b',
+      fontWeight: '600'
+    },
+    activeTab: {
+      background: isDark ? '#4a5568' : '#e2e8f0',
+      color: isDark ? '#f7fafc' : '#1a202c'
+    }
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.tabs}>
+        <button
+          style={{ ...styles.tabButton, ...(activeTab === 'form' ? styles.activeTab : {}) }}
+          onClick={() => setActiveTab('form')}
+        >
+          <CornerUpLeft size={18} /> Saisie
+        </button>
+        <button
+          style={{ ...styles.tabButton, ...(activeTab === 'history' ? styles.activeTab : {}) }}
+          onClick={() => setActiveTab('history')}
+        >
+          <History size={18} /> Historique
+        </button>
+      </div>
+
+      {activeTab === 'form' ? <ReturnForm /> : <ReturnHistory />}
+    </div>
+  );
+};
+
+export default ReturnsModule;


### PR DESCRIPTION
## Summary
- implement employee management with creation, listing, and shift scheduling
- add returns module to record product returns and adjust inventory
- connect new modules to global context and navigation

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm install` *(fails: 403 Forbidden for lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68acdbfa94ec832d82cc207d6e740b10