### PR TITLE
test: add module tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --watchAll=false
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "react-hot-toast": "^2.4.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/modules/cash/CashRegisterModule.test.js
+++ b/src/modules/cash/CashRegisterModule.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CashRegisterModule from './CashRegisterModule';
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    salesHistory: [],
+    appSettings: { darkMode: false, currency: 'FCFA' }
+  })
+}));
+
+test('affiche la caisse et ouvre la modale', () => {
+  render(<CashRegisterModule />);
+  expect(screen.getByText(/Gestion de Caisse/i)).toBeInTheDocument();
+  fireEvent.click(screen.getAllByText(/Ouvrir la caisse/i)[0]);
+  expect(screen.getByText(/Ouverture de Caisse/i)).toBeInTheDocument();
+});
+

--- a/src/modules/inventory/InventoryModule.test.js
+++ b/src/modules/inventory/InventoryModule.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InventoryModule from './InventoryModule';
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    globalProducts: [{ id: 1, name: 'Produit', category: 'A', stock: 10, costPrice: 5, price: 10 }],
+    setGlobalProducts: jest.fn(),
+    addStock: jest.fn(),
+    appSettings: { darkMode: false },
+    salesHistory: []
+  })
+}));
+
+jest.mock('./BarcodeSystem', () => () => <div>BarcodeSystem</div>);
+jest.mock('./PhysicalInventory', () => () => <div>PhysicalInventory</div>);
+
+test("affiche l'inventaire et change d'onglet", () => {
+  render(<InventoryModule />);
+  expect(screen.getByText(/Gestion des Stocks/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Produits'));
+  expect(screen.getByText(/Ajouter Produit/i)).toBeInTheDocument();
+});
+

--- a/src/modules/sales/SalesModule.test.js
+++ b/src/modules/sales/SalesModule.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SalesModule from './SalesModule';
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    globalProducts: [],
+    processSale: jest.fn(),
+    customers: [{ id: 1, name: 'Client Comptant', points: 0 }],
+    appSettings: { darkMode: false, taxRate: 0 },
+    addCredit: jest.fn()
+  })
+}));
+
+jest.mock('../../components/ResponsiveComponents', () => ({
+  useResponsive: () => ({ deviceType: 'desktop', isMobile: false })
+}));
+
+jest.mock('./QuickSale', () => () => <div>QuickSale</div>);
+
+jest.mock('./Cart', () => (props) => (
+  <div>
+    Cart
+    <button onClick={props.onCheckout}>Checkout</button>
+  </div>
+));
+
+jest.mock('./PaymentModal', () => ({ isOpen }) => (isOpen ? <div>Payment Modal</div> : null));
+
+jest.mock('./Receipt', () => () => <div>Receipt</div>);
+
+test('affiche le client et ouvre la modale de paiement', () => {
+  render(<SalesModule />);
+  expect(screen.getByText(/Client/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Checkout'));
+  expect(screen.getByText('Payment Modal')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- add React Testing Library dependencies
- add tests for sales, inventory and cash modules
- setup GitHub Actions workflow to run tests

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace90b6474832d8192de01746476e2