### PR TITLE
feat: add barcode scanning to sales module

### DIFF
--- a/src/modules/sales/BarcodeScanner.jsx
+++ b/src/modules/sales/BarcodeScanner.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const BarcodeScanner = ({ onDetected, onClose }) => {
+  const videoRef = useRef(null);
+  const [manualCode, setManualCode] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let stream;
+    const startScan = async () => {
+      try {
+        if (!('BarcodeDetector' in window)) {
+          setError('Scanner non supporté');
+          return;
+        }
+        stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+        const detector = new window.BarcodeDetector({ formats: ['ean_13', 'code_128', 'upc_e', 'ean_8'] });
+        const scan = async () => {
+          if (!videoRef.current) return;
+          try {
+            const barcodes = await detector.detect(videoRef.current);
+            if (barcodes.length > 0) {
+              onDetected(barcodes[0].rawValue);
+            } else {
+              requestAnimationFrame(scan);
+            }
+          } catch (err) {
+            setError('Erreur de lecture');
+          }
+        };
+        requestAnimationFrame(scan);
+      } catch (err) {
+        setError('Accès caméra refusé');
+      }
+    };
+
+    startScan();
+
+    return () => {
+      if (stream) {
+        stream.getTracks().forEach(t => t.stop());
+      }
+    };
+  }, [onDetected]);
+
+  return (
+    <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.8)', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
+      {error ? (
+        <p style={{ color: '#fff', marginBottom: '10px' }}>{error}</p>
+      ) : (
+        <video ref={videoRef} style={{ width: '80%', maxWidth: '400px' }} />
+      )}
+      <input
+        type="text"
+        placeholder="Entrer le code manuellement"
+        value={manualCode}
+        onChange={(e) => setManualCode(e.target.value)}
+        style={{ marginTop: '10px', padding: '8px', width: '80%', maxWidth: '300px' }}
+      />
+      <div style={{ marginTop: '10px', display: 'flex', gap: '10px' }}>
+        <button
+          onClick={() => manualCode && onDetected(manualCode)}
+          style={{ padding: '6px 12px', background: '#3b82f6', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+        >
+          Valider
+        </button>
+        <button
+          onClick={onClose}
+          style={{ padding: '6px 12px', background: '#ef4444', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+        >
+          Fermer
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BarcodeScanner;
+

--- a/src/modules/sales/QuickSale.jsx
+++ b/src/modules/sales/QuickSale.jsx
@@ -12,7 +12,8 @@ const QuickSale = ({
   cart,
   setCart,
   isDark,
-  appSettings
+  appSettings,
+  openScanner
 }) => {
   const styles = {
     productSection: {
@@ -74,12 +75,27 @@ const QuickSale = ({
         Vider (F1)
       </button>
 
+      <button
+        onClick={openScanner}
+        style={{
+          padding: '6px 12px',
+          background: '#10b981',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+          fontSize: '12px',
+          cursor: 'pointer'
+        }}
+      >
+        Scanner (F4)
+      </button>
+
       <span style={{
         fontSize: '12px',
         color: isDark ? '#a0aec0' : '#64748b',
         alignSelf: 'center'
       }}>
-        F2: Recherche | F3: Payer | Entrée: Ajouter
+        F2: Recherche | F3: Payer | F4: Scanner | Entrée: Ajouter
       </span>
     </div>
   );

--- a/src/modules/sales/SalesModule.jsx
+++ b/src/modules/sales/SalesModule.jsx
@@ -5,6 +5,7 @@ import Cart from './Cart';
 import PaymentModal from './PaymentModal';
 import QuickSale from './QuickSale';
 import Receipt from './Receipt';
+import BarcodeScanner from './BarcodeScanner';
 
 const SalesModule = () => {
   const { globalProducts, processSale, customers, appSettings, addCredit } = useApp();
@@ -17,6 +18,7 @@ const SalesModule = () => {
   const [amountReceived, setAmountReceived] = useState('');
   const [quickMode, setQuickMode] = useState(true);
   const [receipt, setReceipt] = useState(null);
+  const [showScanner, setShowScanner] = useState(false);
 
   const products = globalProducts;
   const isDark = appSettings.darkMode;
@@ -45,6 +47,10 @@ const SalesModule = () => {
       if (e.key === 'F3' && cart.length > 0) {
         e.preventDefault();
         setShowPaymentModal(true);
+      }
+      if (e.key === 'F4') {
+        e.preventDefault();
+        setShowScanner(true);
       }
       if (e.key === 'Escape') {
         if (showPaymentModal) {
@@ -162,8 +168,19 @@ const SalesModule = () => {
 
   const filteredProducts = products.filter(product =>
     product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.sku.toLowerCase().includes(searchQuery.toLowerCase())
+    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    product.barcode?.includes(searchQuery)
   ).slice(0, quickMode ? 12 : 20);
+
+  const handleBarcodeDetected = (code) => {
+    const found = products.find(p => p.barcode === code || p.sku === code);
+    if (found) {
+      addToCart(found);
+      setShowScanner(false);
+    } else {
+      alert('Produit non trouvé');
+    }
+  };
 
   return (
     <div>
@@ -179,6 +196,7 @@ const SalesModule = () => {
           setCart={setCart}
           isDark={isDark}
           appSettings={appSettings}
+          openScanner={() => setShowScanner(true)}
         />
         <Cart
           cart={cart}
@@ -235,6 +253,13 @@ const SalesModule = () => {
           data={receipt}
           onClose={() => setReceipt(null)}
           appSettings={appSettings}
+        />
+      )}
+
+      {showScanner && (
+        <BarcodeScanner
+          onDetected={handleBarcodeDetected}
+          onClose={() => setShowScanner(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow camera-based barcode scanning using BarcodeDetector
- add quick scan button and F4 shortcut in sales module
- support manual barcode input fallback when detection fails

## Testing
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acea37b520832dba92f3e6ac6a492d