### PR TITLE
Add layout and common UI components with demo module

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/**
+ * Simple footer component.
+ */
+const Footer = ({ children }) => {
+  return <footer style={styles.footer}>{children}</footer>;
+};
+
+const styles = {
+  footer: {
+    padding: '1rem',
+    textAlign: 'center',
+    background: '#f8f9fa',
+    borderTop: '1px solid #e5e7eb'
+  }
+};
+
+export default Footer;
+

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Navigation from './Navigation';
+
+/**
+ * Simple header component with optional title and navigation links.
+ */
+const Header = ({ title = '', links = [], children }) => {
+  return (
+    <header style={styles.header}>
+      {title && <h1 style={styles.title}>{title}</h1>}
+      {links.length > 0 && <Navigation links={links} />}
+      {children}
+    </header>
+  );
+};
+
+const styles = {
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '1rem',
+    background: '#f8f9fa',
+    borderBottom: '1px solid #e5e7eb'
+  },
+  title: {
+    margin: 0,
+    fontSize: '1.25rem'
+  }
+};
+
+export default Header;
+

--- a/src/components/Layout/Navigation.jsx
+++ b/src/components/Layout/Navigation.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+/**
+ * Simple horizontal navigation list.
+ */
+const Navigation = ({ links = [] }) => {
+  return (
+    <nav style={styles.nav}>
+      {links.map((link) => (
+        <a key={link.href} href={link.href} style={styles.link}>
+          {link.label}
+        </a>
+      ))}
+    </nav>
+  );
+};
+
+const styles = {
+  nav: {
+    display: 'flex',
+    gap: '1rem'
+  },
+  link: {
+    color: '#2563eb',
+    textDecoration: 'none'
+  }
+};
+
+export default Navigation;
+

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/**
+ * Basic sidebar container.
+ */
+const Sidebar = ({ children }) => {
+  return <aside style={styles.sidebar}>{children}</aside>;
+};
+
+const styles = {
+  sidebar: {
+    width: '220px',
+    padding: '1rem',
+    background: '#f1f5f9',
+    borderRight: '1px solid #e5e7eb'
+  }
+};
+
+export default Sidebar;
+

--- a/src/components/common/ConfirmDialog.jsx
+++ b/src/components/common/ConfirmDialog.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+/**
+ * Simple confirmation dialog.
+ */
+const ConfirmDialog = ({ isOpen, message, onConfirm, onCancel }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div style={styles.overlay}>
+      <div style={styles.box}>
+        <p>{message}</p>
+        <div style={styles.actions}>
+          <button onClick={onCancel}>Cancel</button>
+          <button onClick={onConfirm}>Confirm</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const styles = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'rgba(0,0,0,0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000
+  },
+  box: {
+    background: '#fff',
+    padding: '1rem',
+    borderRadius: '8px',
+    minWidth: '280px'
+  },
+  actions: {
+    marginTop: '1rem',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '0.5rem'
+  }
+};
+
+export default ConfirmDialog;
+

--- a/src/components/common/DataTable.jsx
+++ b/src/components/common/DataTable.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+/**
+ * Minimal data table component.
+ */
+const DataTable = ({ columns = [], data = [] }) => {
+  return (
+    <table style={styles.table}>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col} style={styles.th}>
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            {columns.map((col) => (
+              <td key={col} style={styles.td}>
+                {row[col]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const styles = {
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse'
+  },
+  th: {
+    border: '1px solid #e5e7eb',
+    padding: '0.5rem',
+    textAlign: 'left',
+    background: '#f1f5f9'
+  },
+  td: {
+    border: '1px solid #e5e7eb',
+    padding: '0.5rem'
+  }
+};
+
+export default DataTable;
+

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * Error boundary to catch rendering errors in children components.
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;
+

--- a/src/components/common/LoadingSpinner.jsx
+++ b/src/components/common/LoadingSpinner.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+/**
+ * Simple loading spinner.
+ */
+const LoadingSpinner = () => {
+  return (
+    <div style={styles.spinner}>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};
+
+const styles = {
+  spinner: {
+    width: '40px',
+    height: '40px',
+    border: '4px solid #e5e7eb',
+    borderTopColor: '#3b82f6',
+    borderRadius: '50%',
+    animation: 'spin 1s linear infinite',
+    margin: '1rem auto'
+  }
+};
+
+export default LoadingSpinner;
+

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+/**
+ * Basic modal component.
+ */
+const Modal = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div style={styles.overlay} onClick={onClose}>
+      <div style={styles.content} onClick={(e) => e.stopPropagation()}>
+        {children}
+        <button style={styles.closeButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const styles = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'rgba(0,0,0,0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000
+  },
+  content: {
+    background: '#fff',
+    padding: '1rem',
+    borderRadius: '8px',
+    minWidth: '300px',
+    maxWidth: '90%'
+  },
+  closeButton: {
+    marginTop: '1rem'
+  }
+};
+
+export default Modal;
+

--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const COLORS = {
+  success: '#16a34a',
+  error: '#dc2626',
+  info: '#2563eb',
+  warning: '#f59e0b'
+};
+
+/**
+ * Simple toast message.
+ */
+const Toast = ({ message, type = 'info' }) => {
+  return (
+    <div
+      style={{
+        padding: '0.5rem 1rem',
+        background: COLORS[type] || COLORS.info,
+        color: '#fff',
+        borderRadius: '4px',
+        margin: '0.25rem 0'
+      }}
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toast;
+

--- a/src/modules/demo/DemoModule.jsx
+++ b/src/modules/demo/DemoModule.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import Header from '../../components/Layout/Header';
+import Sidebar from '../../components/Layout/Sidebar';
+import Footer from '../../components/Layout/Footer';
+import Modal from '../../components/common/Modal';
+import Toast from '../../components/common/Toast';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
+import ConfirmDialog from '../../components/common/ConfirmDialog';
+import DataTable from '../../components/common/DataTable';
+import ErrorBoundary from '../../components/common/ErrorBoundary';
+
+const DemoModule = () => {
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const columns = ['name', 'value'];
+  const data = [
+    { name: 'Item 1', value: 100 },
+    { name: 'Item 2', value: 200 }
+  ];
+
+  return (
+    <ErrorBoundary>
+      <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <Header title="Components Demo" links={[{ href: '#', label: 'Home' }, { href: '#modal', label: 'Modal' }]} />
+        <div style={{ display: 'flex', flex: 1 }}>
+          <Sidebar>
+            <button onClick={() => setModalOpen(true)}>Open Modal</button>
+            <button onClick={() => setShowConfirm(true)}>Confirm</button>
+          </Sidebar>
+          <main style={{ flex: 1, padding: '1rem' }}>
+            <Toast message="This is a toast" type="info" />
+            <LoadingSpinner />
+            <DataTable columns={columns} data={data} />
+          </main>
+        </div>
+        <Footer>Demo Footer</Footer>
+
+        <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
+          <h2>Simple Modal</h2>
+        </Modal>
+
+        <ConfirmDialog
+          isOpen={showConfirm}
+          message="Are you sure?"
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={() => setShowConfirm(false)}
+        />
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default DemoModule;
+


### PR DESCRIPTION
## Summary
- implement basic layout components: Header, Sidebar, Navigation, Footer
- add common UI elements: Modal, Toast, LoadingSpinner, ConfirmDialog, DataTable, ErrorBoundary
- create demo module showcasing the new components

## Testing
- `npm test -- --watchAll=false` (fails: react-scripts not found)
- `npm install` (fails: 403 Forbidden while fetching @testing-library/jest-dom)


------
https://chatgpt.com/codex/tasks/task_e_68acef923b78832da6ccd0a1686554b2