### PR TITLE
refactor: centralize module styles

### DIFF
--- a/src/components/ResponsiveComponents.js
+++ b/src/components/ResponsiveComponents.js
@@ -133,11 +133,18 @@ export const getResponsiveStyles = (deviceType, isDark) => {
     grid: {
       display: 'grid',
       gap: deviceType === 'mobile' ? '12px' : '15px',
-      gridTemplateColumns: deviceType === 'mobile' ? 
+      gridTemplateColumns: deviceType === 'mobile' ?
         'repeat(auto-fit, minmax(140px, 1fr))' :
         deviceType === 'tablet' ?
         'repeat(auto-fit, minmax(160px, 1fr))' :
         'repeat(auto-fit, minmax(180px, 1fr))'
+    },
+
+    header: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: deviceType === 'mobile' ? '15px' : '20px'
     },
 
     modal: {

--- a/src/modules/cash/CashRegisterModule.jsx
+++ b/src/modules/cash/CashRegisterModule.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Calculator, Clock, DollarSign, FileText, Printer, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
+import { useResponsive, getResponsiveStyles } from '../../components/ResponsiveComponents';
 
 const CashRegisterModule = () => {
   const { salesHistory, appSettings } = useApp();
@@ -13,6 +14,8 @@ const CashRegisterModule = () => {
   const [notes, setNotes] = useState('');
 
   const isDark = appSettings.darkMode;
+  const { deviceType } = useResponsive();
+  const sharedStyles = getResponsiveStyles(deviceType, isDark);
 
   // Charger la session de caisse actuelle
   useEffect(() => {
@@ -147,34 +150,6 @@ const CashRegisterModule = () => {
   const expectedCash = cashSession ? cashSession.openingAmount + (totals?.cashSales || 0) : 0;
 
   const styles = {
-    container: {
-      padding: '20px',
-      background: isDark ? '#1a202c' : '#f7fafc',
-      minHeight: 'calc(100vh - 120px)'
-    },
-    card: {
-      background: isDark ? '#2d3748' : 'white',
-      padding: '20px',
-      borderRadius: '8px',
-      boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-      marginBottom: '20px'
-    },
-    header: {
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      marginBottom: '20px'
-    },
-    button: {
-      padding: '10px 20px',
-      border: 'none',
-      borderRadius: '6px',
-      cursor: 'pointer',
-      fontWeight: '600',
-      display: 'flex',
-      alignItems: 'center',
-      gap: '8px'
-    },
     grid: {
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
@@ -183,9 +158,9 @@ const CashRegisterModule = () => {
   };
 
   return (
-    <div style={styles.container}>
+    <div style={sharedStyles.container}>
       {/* En-tête */}
-      <div style={styles.header}>
+      <div style={sharedStyles.header}>
         <h1 style={{ 
           fontSize: '24px', 
           fontWeight: 'bold', 
@@ -198,11 +173,7 @@ const CashRegisterModule = () => {
           {!cashSession ? (
             <button
               onClick={() => setShowOpenModal(true)}
-              style={{
-                ...styles.button,
-                background: '#10b981',
-                color: 'white'
-              }}
+              style={{ ...sharedStyles.button, background: '#10b981', color: 'white' }}
             >
               <CheckCircle size={18} />
               Ouvrir la caisse
@@ -210,11 +181,7 @@ const CashRegisterModule = () => {
           ) : (
             <button
               onClick={() => setShowCloseModal(true)}
-              style={{
-                ...styles.button,
-                background: '#ef4444',
-                color: 'white'
-              }}
+              style={{ ...sharedStyles.button, background: '#ef4444', color: 'white' }}
             >
               <XCircle size={18} />
               Fermer la caisse
@@ -225,7 +192,7 @@ const CashRegisterModule = () => {
 
       {!cashSession ? (
         // Caisse fermée
-        <div style={styles.card}>
+        <div style={sharedStyles.card}>
           <div style={{ textAlign: 'center', padding: '40px' }}>
             <XCircle size={64} color="#ef4444" style={{ margin: '0 auto 20px' }} />
             <h2 style={{ 
@@ -240,11 +207,7 @@ const CashRegisterModule = () => {
             </p>
             <button
               onClick={() => setShowOpenModal(true)}
-              style={{
-                ...styles.button,
-                background: '#10b981',
-                color: 'white'
-              }}
+              style={{ ...sharedStyles.button, background: '#10b981', color: 'white' }}
             >
               <CheckCircle size={18} />
               Ouvrir la caisse
@@ -255,7 +218,7 @@ const CashRegisterModule = () => {
         // Caisse ouverte - Tableau de bord
         <>
           {/* Statut de la session */}
-          <div style={styles.card}>
+          <div style={sharedStyles.card}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '15px', marginBottom: '15px' }}>
               <CheckCircle size={24} color="#10b981" />
               <div>
@@ -300,7 +263,7 @@ const CashRegisterModule = () => {
 
           {/* Résumé des ventes */}
           {totals && (
-            <div style={styles.card}>
+            <div style={sharedStyles.card}>
               <h3 style={{ 
                 fontSize: '18px', 
                 fontWeight: '600', 
@@ -372,7 +335,7 @@ const CashRegisterModule = () => {
           )}
 
           {/* Opérations de caisse */}
-          <div style={styles.card}>
+          <div style={sharedStyles.card}>
             <h3 style={{ 
               fontSize: '18px', 
               fontWeight: '600', 

--- a/src/modules/credits/CreditManagementModule.jsx
+++ b/src/modules/credits/CreditManagementModule.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Users, CreditCard, AlertTriangle, Clock, Check, Phone, Plus, Eye, FileText } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
+import { useResponsive, getResponsiveStyles } from '../../components/ResponsiveComponents';
 
 const CreditManagementModule = () => {
   const { customers, setCustomers, appSettings, credits, setCredits } = useApp();
@@ -17,6 +18,8 @@ const CreditManagementModule = () => {
   const [activeTab, setActiveTab] = useState('pending');
 
   const isDark = appSettings.darkMode;
+  const { deviceType } = useResponsive();
+  const sharedStyles = getResponsiveStyles(deviceType, isDark);
 
   // Sauvegarder automatiquement
   useEffect(() => {
@@ -141,24 +144,6 @@ const CreditManagementModule = () => {
   const filteredCredits = getFilteredCredits();
 
   const styles = {
-    container: {
-      padding: '20px',
-      background: isDark ? '#1a202c' : '#f7fafc',
-      minHeight: 'calc(100vh - 120px)'
-    },
-    card: {
-      background: isDark ? '#2d3748' : 'white',
-      padding: '20px',
-      borderRadius: '8px',
-      boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-      marginBottom: '20px'
-    },
-    header: {
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      marginBottom: '20px'
-    },
     tabs: {
       display: 'flex',
       gap: '10px',
@@ -197,12 +182,12 @@ const CreditManagementModule = () => {
   };
 
   return (
-    <div style={styles.container}>
+    <div style={sharedStyles.container}>
       {/* En-tête */}
-      <div style={styles.header}>
-        <h1 style={{ 
-          fontSize: '24px', 
-          fontWeight: 'bold', 
+      <div style={sharedStyles.header}>
+        <h1 style={{
+          fontSize: '24px',
+          fontWeight: 'bold',
           color: isDark ? '#f7fafc' : '#2d3748' 
         }}>
           Gestion des Crédits Clients
@@ -210,18 +195,7 @@ const CreditManagementModule = () => {
         
         <button
           onClick={() => setShowAddCreditModal(true)}
-          style={{
-            padding: '10px 20px',
-            background: '#3b82f6',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontWeight: '600',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px'
-          }}
+          style={{ ...sharedStyles.button, background: '#3b82f6', color: 'white' }}
         >
           <Plus size={18} />
           Nouveau Crédit
@@ -314,7 +288,7 @@ const CreditManagementModule = () => {
       </div>
 
       {/* Liste des crédits */}
-      <div style={styles.card}>
+      <div style={sharedStyles.card}>
         {filteredCredits.length === 0 ? (
           <div style={{ 
             textAlign: 'center', 

--- a/src/modules/employees/EmployeesModule.jsx
+++ b/src/modules/employees/EmployeesModule.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Users, UserPlus, Clock } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
+import { useResponsive, getResponsiveStyles } from '../../components/ResponsiveComponents';
 import EmployeeForm from './EmployeeForm';
 import EmployeeList from './EmployeeList';
 import ShiftManagement from './ShiftManagement';
@@ -9,13 +10,10 @@ const EmployeesModule = () => {
   const { appSettings } = useApp();
   const [activeTab, setActiveTab] = useState('list');
   const isDark = appSettings.darkMode;
+  const { deviceType } = useResponsive();
+  const sharedStyles = getResponsiveStyles(deviceType, isDark);
 
   const styles = {
-    container: {
-      padding: '20px',
-      background: isDark ? '#1a202c' : '#f7fafc',
-      minHeight: 'calc(100vh - 120px)'
-    },
     tabs: {
       display: 'flex',
       gap: '10px',
@@ -45,7 +43,7 @@ const EmployeesModule = () => {
   };
 
   return (
-    <div style={styles.container}>
+    <div style={sharedStyles.container}>
       <div style={styles.tabs}>
         <button
           style={{ ...styles.tabButton, ...(activeTab === 'list' ? styles.activeTab : {}) }}


### PR DESCRIPTION
## Summary
- add shared header style to `getResponsiveStyles`
- refactor employees, credits, and cash modules to reuse responsive styles

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `npm install --no-audit --prefer-offline` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68acef94da88832d9c6d909032ffad41