### PR TITLE
test: add module tests

### DIFF
--- a/src/modules/customers/CustomersModule.test.js
+++ b/src/modules/customers/CustomersModule.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import CustomersModule from './CustomersModule';
+import { AppProvider } from '../../contexts/AppContext';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('affiche la liste des clients par défaut', () => {
+  render(
+    <AppProvider>
+      <CustomersModule />
+    </AppProvider>
+  );
+  expect(screen.getByText(/Aucun client enregistré/i)).toBeInTheDocument();
+});
+
+test('ajoute et supprime un client', () => {
+  render(
+    <AppProvider>
+      <CustomersModule />
+    </AppProvider>
+  );
+
+  fireEvent.change(screen.getByPlaceholderText('Nom'), { target: { value: 'Alice' } });
+  fireEvent.change(screen.getByPlaceholderText('Téléphone'), { target: { value: '555' } });
+  fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@a.com' } });
+  fireEvent.click(screen.getByRole('button', { name: /Ajouter/i }));
+
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+
+  window.confirm = jest.fn().mockReturnValue(true);
+  const row = screen.getByText('Alice').closest('tr');
+  fireEvent.click(within(row).getByRole('button'));
+  expect(screen.getByText(/Aucun client enregistré/i)).toBeInTheDocument();
+});
+
+test("n'ajoute pas de client sans nom", () => {
+  render(
+    <AppProvider>
+      <CustomersModule />
+    </AppProvider>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /Ajouter/i }));
+  expect(screen.getByText(/Aucun client enregistré/i)).toBeInTheDocument();
+});

--- a/src/modules/employees/EmployeesModule.test.js
+++ b/src/modules/employees/EmployeesModule.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import EmployeesModule from './EmployeesModule';
+import { AppProvider } from '../../contexts/AppContext';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('affiche la liste des employés par défaut', () => {
+  render(
+    <AppProvider>
+      <EmployeesModule />
+    </AppProvider>
+  );
+  expect(screen.getByText(/Aucun employé/i)).toBeInTheDocument();
+});
+
+test('ajoute et supprime un employé', () => {
+  render(
+    <AppProvider>
+      <EmployeesModule />
+    </AppProvider>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /Ajouter/i }));
+  fireEvent.change(screen.getByPlaceholderText('Nom'), { target: { value: 'Jean' } });
+  fireEvent.change(screen.getByPlaceholderText('Rôle'), { target: { value: 'Caissier' } });
+  fireEvent.change(screen.getByPlaceholderText('Téléphone'), { target: { value: '123' } });
+  fireEvent.click(screen.getAllByRole('button', { name: /Ajouter/i })[1]);
+
+  fireEvent.click(screen.getByRole('button', { name: /Liste/i }));
+  expect(screen.getByText('Jean')).toBeInTheDocument();
+
+  window.confirm = jest.fn().mockReturnValue(true);
+  const row = screen.getByText('Jean').closest('tr');
+  fireEvent.click(within(row).getByRole('button'));
+  expect(screen.getByText(/Aucun employé/i)).toBeInTheDocument();
+});
+
+test("n'ajoute pas d'employé sans nom", () => {
+  render(
+    <AppProvider>
+      <EmployeesModule />
+    </AppProvider>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /Ajouter/i }));
+  fireEvent.click(screen.getAllByRole('button', { name: /Ajouter/i })[1]);
+  fireEvent.click(screen.getByRole('button', { name: /Liste/i }));
+  expect(screen.getByText(/Aucun employé/i)).toBeInTheDocument();
+});

--- a/src/modules/returns/ReturnsModule.test.js
+++ b/src/modules/returns/ReturnsModule.test.js
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ReturnsModule from './ReturnsModule';
+import { AppProvider, useApp } from '../../contexts/AppContext';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const Setup = () => {
+  const { setGlobalProducts } = useApp();
+  useEffect(() => {
+    setGlobalProducts([{ id: 1, name: 'Produit A', stock: 5 }]);
+  }, [setGlobalProducts]);
+  return <ReturnsModule />;
+};
+
+test('affiche le formulaire de retour par défaut', () => {
+  render(
+    <AppProvider>
+      <ReturnsModule />
+    </AppProvider>
+  );
+  expect(screen.getByText(/Enregistrer/i)).toBeInTheDocument();
+});
+
+test('enregistre un retour et l\'affiche dans l\'historique', async () => {
+  render(
+    <AppProvider>
+      <Setup />
+    </AppProvider>
+  );
+
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
+  fireEvent.change(screen.getByPlaceholderText('Quantité'), { target: { value: '2' } });
+  fireEvent.change(screen.getByPlaceholderText('Raison'), { target: { value: 'Défaut' } });
+  fireEvent.click(screen.getByRole('button', { name: /Enregistrer/i }));
+
+  fireEvent.click(screen.getByRole('button', { name: /Historique/i }));
+  await waitFor(() => expect(screen.getByText('Produit A')).toBeInTheDocument());
+});
+
+test("affiche un message d'erreur lorsqu'il n'y a pas de retour", () => {
+  render(
+    <AppProvider>
+      <ReturnsModule />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Historique/i }));
+  expect(screen.getByText(/Aucun retour enregistré/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add React Testing Library tests for EmployeesModule covering default list, add/remove, and empty-name validation
- add tests for CustomersModule including add/remove interactions and missing-name check
- create ReturnsModule tests for form default, recording returns, and empty history message

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test --silent` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68acef96bc14832d8fccc14b785abe52