### PR TITLE
feat: support consolidated view in POS

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import ReportsModule from './modules/reports/ReportsModule';
 import EmployeesModule from './modules/employees/EmployeesModule';
 import ReturnsModule from './modules/returns/ReturnsModule';
 import { MobileNavigation, useResponsive } from './components/ResponsiveComponents';
+import StoreSelector from './components/StoreSelector';
 import { ShoppingCart, Package, Users, Home, BarChart3, Settings, Calculator, CreditCard, UserCog, RotateCcw } from 'lucide-react';
 import styles from './App.module.css';
 
@@ -145,6 +146,7 @@ function AppContent() {
           <h1 className={styles.headerTitle}>
             {appSettings.storeName || 'POS Superette'}
           </h1>
+          <StoreSelector />
         </div>
 
         <div className={styles.headerRight}>


### PR DESCRIPTION
## Summary
- show store selector in main header
- load data for all stores when viewing consolidated mode
- return null for current store when consolidated

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ad577b50d4832d8a076e1e06778c2a