### PR TITLE
Add store-specific employee creation and restrict stores per user

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,11 +19,11 @@ import styles from './App.module.css';
 // Composant principal avec les Providers
 function App() {
   return (
-    <AuthProvider>
-      <AppProvider>
+    <AppProvider>
+      <AuthProvider>
         <AppContent />
-      </AppProvider>
-    </AuthProvider>
+      </AuthProvider>
+    </AppProvider>
   );
 }
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -2,13 +2,16 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { auth, db } from '../config/firebase';
 import { onAuthStateChanged, signInWithEmailAndPassword, signOut } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
+import { useApp } from './AppContext';
 
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [role, setRole] = useState(null);
+  const [allowedStores, setAllowedStores] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { setCurrentStoreId } = useApp();
 
   const login = async (email, password) => {
     await signInWithEmailAndPassword(auth, email, password);
@@ -23,21 +26,34 @@ export function AuthProvider({ children }) {
         try {
           const docRef = doc(db, 'users', firebaseUser.uid);
           const docSnap = await getDoc(docRef);
-          setRole(docSnap.exists() ? docSnap.data().role : null);
+          if (docSnap.exists()) {
+            const data = docSnap.data();
+            setRole(data.role || null);
+            const stores = data.stores || [];
+            setAllowedStores(stores);
+            if (stores.length) {
+              setCurrentStoreId(stores[0]);
+            }
+          } else {
+            setRole(null);
+            setAllowedStores([]);
+          }
         } catch (e) {
           setRole(null);
+          setAllowedStores([]);
         }
       } else {
         setRole(null);
+        setAllowedStores([]);
       }
       setLoading(false);
     });
 
     return unsubscribe;
-  }, []);
+  }, [setCurrentStoreId]);
 
   return (
-    <AuthContext.Provider value={{ user, role, login, logout, loading }}>
+    <AuthContext.Provider value={{ user, role, login, logout, loading, allowedStores }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/modules/employees/EmployeeForm.jsx
+++ b/src/modules/employees/EmployeeForm.jsx
@@ -3,8 +3,8 @@ import { Plus } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 
 const EmployeeForm = () => {
-  const { employees, setEmployees, appSettings } = useApp();
-  const [form, setForm] = useState({ name: '', role: '', phone: '' });
+  const { employees, setEmployees, appSettings, stores, currentStoreId } = useApp();
+  const [form, setForm] = useState({ name: '', role: '', phone: '', storeId: currentStoreId });
   const isDark = appSettings.darkMode;
 
   const handleChange = (e) => {
@@ -18,10 +18,11 @@ const EmployeeForm = () => {
       name: form.name.trim(),
       role: form.role.trim(),
       phone: form.phone.trim(),
+      storeId: form.storeId,
       shifts: []
     };
     setEmployees([...(employees || []), newEmployee]);
-    setForm({ name: '', role: '', phone: '' });
+    setForm({ name: '', role: '', phone: '', storeId: currentStoreId });
   };
 
   const styles = {
@@ -75,6 +76,18 @@ const EmployeeForm = () => {
         onChange={handleChange}
         style={styles.input}
       />
+      <select
+        name="storeId"
+        value={form.storeId}
+        onChange={handleChange}
+        style={styles.input}
+      >
+        {(stores || []).map(store => (
+          <option key={store.id} value={store.id}>
+            {store.name}
+          </option>
+        ))}
+      </select>
       <button onClick={addEmployee} style={styles.addButton}>
         <Plus size={16} /> Ajouter
       </button>


### PR DESCRIPTION
## Summary
- Allow selecting a store when creating employees and save the `storeId` with each employee
- Load authorized store list on login and set current store accordingly
- Wrap auth inside app provider so store state is available during auth

## Testing
- ⚠️ `npm test -- --watchAll=false` *(react-scripts: not found; `npm install` failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d333770832daf19adc09af8ba21