### PR TITLE
feat: use store-specific settings

### DIFF
--- a/src/modules/settings/SettingsModule.jsx
+++ b/src/modules/settings/SettingsModule.jsx
@@ -25,6 +25,10 @@ const SettingsModule = () => {
   const currentStore = getCurrentStore();
   const stats = getStats();
 
+  useEffect(() => {
+    setLocalSettings(appSettings);
+  }, [appSettings]);
+
   // Détecter les changements
   useEffect(() => {
     const hasChanged = JSON.stringify(localSettings) !== JSON.stringify(appSettings);


### PR DESCRIPTION
## Summary
- load app settings from store-specific local storage and default to store name
- keep appSettings.storeName in sync when switching stores
- sync SettingsModule with current store configuration

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad65512e08832d9eca0b653a0b579e