### PR TITLE
Add Firebase env template and explicit config validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Example environment variables for the application
+# Copy this file to `.env` and fill in the values.
 
 # Firebase configuration
 REACT_APP_FIREBASE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Static files like `index.html` reside in the `public/` directory.
 
 Le fichier `.env.example` répertorie toutes les variables d’environnement utilisées par l’application. Remplacez les valeurs par celles de votre projet avant de lancer l’application.
 
+## Déploiement sur Vercel
+
+1. Importez ce dépôt dans [Vercel](https://vercel.com/) via **New Project** et sélectionnez la source GitHub correspondante.
+2. Dans l’onglet **Settings > Environment Variables**, créez les variables listées dans `.env.example` (`REACT_APP_FIREBASE_API_KEY`, `REACT_APP_FIREBASE_AUTH_DOMAIN`, etc.) pour les environnements **Production** et **Preview**.
+3. Conservez la commande de build par défaut `npm run build` et le dossier de sortie `build` (valeurs par défaut de Create React App).
+4. Déployez le projet. Vercel utilisera ces variables lors du build et à l’exécution.
+
 ## Dépendances clés
 
 - [Firebase](https://firebase.google.com/) : authentification et base de données.

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -2,6 +2,22 @@ import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 
+const requiredEnv = [
+  'REACT_APP_FIREBASE_API_KEY',
+  'REACT_APP_FIREBASE_AUTH_DOMAIN',
+  'REACT_APP_FIREBASE_PROJECT_ID',
+  'REACT_APP_FIREBASE_STORAGE_BUCKET',
+  'REACT_APP_FIREBASE_MESSAGING_SENDER_ID',
+  'REACT_APP_FIREBASE_APP_ID',
+  'REACT_APP_FIREBASE_MEASUREMENT_ID',
+];
+
+const missing = requiredEnv.filter((key) => !process.env[key]);
+
+if (missing.length) {
+  throw new Error(`Missing Firebase environment variables: ${missing.join(', ')}`);
+}
+
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,


### PR DESCRIPTION
## Summary
- add example `.env` with Firebase keys
- validate required Firebase env vars on init
- document deployment steps for Vercel

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad68301010832daf6e0b375cea513e