### PR TITLE
feat: notify service worker update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,15 @@ Le fichier `.env.example` répertorie toutes les variables d’environnement uti
 - [lucide-react](https://lucide.dev/) : bibliothèque d’icônes.
 - Service worker (`src/serviceWorkerRegistration.js`) : support hors‑ligne et cache.
 
+## Vider le cache du service worker
+
+En cas de besoin, vous pouvez supprimer le cache depuis la console du navigateur :
+
+```js
+navigator.serviceWorker
+  .getRegistrations()
+  .then((regs) => regs.forEach((reg) => reg.unregister()));
+```
+
+Rechargez ensuite la page pour réinstaller un service worker propre.
+

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -6,6 +6,29 @@ const isLocalhost = Boolean(
     )
 );
 
+function showUpdateButton(registration) {
+  const id = 'sw-update-button';
+  if (document.getElementById(id)) {
+    return;
+  }
+  const button = document.createElement('button');
+  button.id = id;
+  button.textContent = 'Nouvelle version disponible';
+  Object.assign(button.style, {
+    position: 'fixed',
+    bottom: '1rem',
+    right: '1rem',
+    zIndex: 1000,
+  });
+  button.addEventListener('click', () => {
+    if (registration.waiting) {
+      registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+    }
+    window.location.reload();
+  });
+  document.body.appendChild(button);
+}
+
 export function register(config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
@@ -43,6 +66,7 @@ function registerValidSW(swUrl, config) {
           if (installingWorker.state === 'installed') {
             if (navigator.serviceWorker.controller) {
               console.log('New content is available; please refresh.');
+              showUpdateButton(registration);
               if (config && config.onUpdate) {
                 config.onUpdate(registration);
               }


### PR DESCRIPTION
## Summary
- prompt user to reload when a new service worker is installed
- document how to clear the service worker cache

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7280f4b4832dbf675b8311a2e599