### PR TITLE
fix: define filteredProducts before effect

### DIFF
--- a/src/modules/sales/SalesModule.jsx
+++ b/src/modules/sales/SalesModule.jsx
@@ -27,6 +27,12 @@ const SalesModule = () => {
 
   const frequentAmounts = [500, 1000, 2000, 5000, 10000, 20000];
 
+  const filteredProducts = products.filter(product =>
+    product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    product.barcode?.includes(searchQuery)
+  ).slice(0, quickMode ? 12 : 20);
+
   useEffect(() => {
     const subtotal = cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);
     const tax = subtotal * (appSettings.taxRate / 100);
@@ -165,12 +171,6 @@ const SalesModule = () => {
     setSearchQuery('');
     document.getElementById('product-search')?.focus();
   };
-
-  const filteredProducts = products.filter(product =>
-    product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.barcode?.includes(searchQuery)
-  ).slice(0, quickMode ? 12 : 20);
 
   const handleBarcodeDetected = (code) => {
     const found = products.find(p => p.barcode === code || p.sku === code);


### PR DESCRIPTION
## Summary
- Define `filteredProducts` before the keyboard shortcut effect to avoid access before initialization
- Remove redundant `filteredProducts` declaration later in the component

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d0de6e8832db98bba1d9a21c861