### PR TITLE
Prevent keydown effect from referencing undefined filteredProducts

### DIFF
--- a/src/modules/sales/SalesModule.jsx
+++ b/src/modules/sales/SalesModule.jsx
@@ -27,17 +27,17 @@ const SalesModule = () => {
 
   const frequentAmounts = [500, 1000, 2000, 5000, 10000, 20000];
 
-  const filteredProducts = products.filter(product =>
-    product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.barcode?.includes(searchQuery)
-  ).slice(0, quickMode ? 12 : 20);
-
   useEffect(() => {
     const subtotal = cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);
     const tax = subtotal * (appSettings.taxRate / 100);
     setTotal(subtotal + tax);
   }, [cart, appSettings.taxRate]);
+
+  const filteredProducts = products.filter(product =>
+    product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    product.barcode?.includes(searchQuery)
+  ).slice(0, quickMode ? 12 : 20);
 
   useEffect(() => {
     const handleKeyDown = (e) => {


### PR DESCRIPTION
## Summary
- Move `filteredProducts` declaration above the keydown `useEffect` in SalesModule to ensure it's defined before being referenced

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ae22d6b764832db8db98abd281fd48