### PR TITLE
fix: preserve current time for daily metrics

### DIFF
--- a/src/modules/dashboard/DashboardModule.jsx
+++ b/src/modules/dashboard/DashboardModule.jsx
@@ -35,10 +35,12 @@ const DashboardModule = () => {
   // Calculs avancés pour les métriques comparatives
   const dashboardMetrics = useMemo(() => {
     const now = new Date();
-    
+    const startOfToday = new Date(now);
+    startOfToday.setHours(0, 0, 0, 0);
+
     // Définir les périodes
     const periods = {
-      today: { start: new Date(now.setHours(0,0,0,0)), label: "Aujourd'hui" },
+      today: { start: startOfToday, label: "Aujourd'hui" },
       week: { start: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), label: "7 derniers jours" },
       month: { start: new Date(now.getFullYear(), now.getMonth(), 1), label: "Ce mois" },
       year: { start: new Date(now.getFullYear(), 0, 1), label: "Cette année" }


### PR DESCRIPTION
## Summary
- compute a separate `startOfToday` to avoid mutating `now`
- use the unmodified `now` when calculating previous-period comparisons

## Testing
- `node -e "const now=new Date(); const startOfToday=new Date(now); startOfToday.setHours(0,0,0,0); const periods={today:{start:startOfToday}}; const currentPeriod=periods['today']; const salesHistory=[{date:new Date(now.getFullYear(), now.getMonth(), now.getDate(), 10).toISOString(), total:100},{date:new Date(startOfToday.getTime() - (now - startOfToday)/2).toISOString(), total:50}]; const currentSales=salesHistory.filter(s=>new Date(s.date)>=currentPeriod.start); const periodDuration=now.getTime()-currentPeriod.start.getTime(); const previousPeriodStart=new Date(currentPeriod.start.getTime()-periodDuration); const previousSales=salesHistory.filter(s=>new Date(s.date)>=previousPeriodStart && new Date(s.date)<currentPeriod.start); console.log({periodDuration,currentSalesLength:currentSales.length,previousSalesLength:previousSales.length});"`
- `CI=true npm test` (fails: react-scripts not found)
- `npm install` (fails: 403 Forbidden for @testing-library/jest-dom)`

------
https://chatgpt.com/codex/tasks/task_e_68ae2854937c832da3a3cf640da36d7d