### PR TITLE
Refactor dashboard widgets into separate components

### DIFF
--- a/src/modules/dashboard/components/AlertsWidget.jsx
+++ b/src/modules/dashboard/components/AlertsWidget.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { AlertTriangle, Package, Clock, Bell } from 'lucide-react';
+
+const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAlerts, isDark }) => {
+  const lowStockProducts = globalProducts.filter(p => (p.stock || 0) > 0 && (p.stock || 0) <= (p.minStock || 5));
+  const outOfStockProducts = globalProducts.filter(p => (p.stock || 0) === 0);
+  const overdueCredits = credits.filter(c => {
+    if (!c.dueDate) return false;
+    const dueDate = new Date(c.dueDate);
+    return (c.status === 'pending' || c.status === 'partial') && dueDate < new Date();
+  });
+
+  const alerts = [];
+
+  if (outOfStockProducts.length > 0) {
+    alerts.push({
+      type: 'error',
+      icon: AlertTriangle,
+      title: 'Ruptures de Stock',
+      message: `${outOfStockProducts.length} produit(s) en rupture`,
+      action: 'Voir Stocks'
+    });
+  }
+
+  if (lowStockProducts.length > 0) {
+    alerts.push({
+      type: 'warning',
+      icon: Package,
+      title: 'Stock Faible',
+      message: `${lowStockProducts.length} produit(s) en stock faible`,
+      action: 'Réapprovisionner'
+    });
+  }
+
+  if (overdueCredits.length > 0) {
+    alerts.push({
+      type: 'error',
+      icon: Clock,
+      title: 'Crédits en Retard',
+      message: `${overdueCredits.length} crédit(s) en retard`,
+      action: 'Voir Crédits'
+    });
+  }
+
+  if (!showAlerts || alerts.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: '25px' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: '15px'
+      }}>
+        <h3 style={{
+          fontSize: '18px',
+          fontWeight: 'bold',
+          color: isDark ? '#f7fafc' : '#2d3748',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          margin: 0
+        }}>
+          <Bell size={20} />
+          Alertes Importantes
+        </h3>
+        <button
+          onClick={() => setShowAlerts(false)}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: isDark ? '#a0aec0' : '#64748b',
+            cursor: 'pointer',
+            padding: '4px'
+          }}
+        >
+          Masquer
+        </button>
+      </div>
+
+      {alerts.map((alert, index) => (
+        <div key={index} style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          padding: '16px',
+          background: isDark ? '#2d3748' : 'white',
+          borderRadius: '8px',
+          marginBottom: '12px',
+          border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`
+        }}>
+          <alert.icon size={20} color={alert.type === 'error' ? '#ef4444' : '#f59e0b'} />
+          <div style={{ flex: 1 }}>
+            <div style={{
+              fontWeight: '600',
+              color: isDark ? '#f7fafc' : '#2d3748',
+              marginBottom: '2px'
+            }}>
+              {alert.title}
+            </div>
+            <div style={{
+              fontSize: '14px',
+              color: isDark ? '#a0aec0' : '#64748b'
+            }}>
+              {alert.message}
+            </div>
+          </div>
+          <button style={{
+            padding: '6px 12px',
+            background: alert.type === 'error' ? '#ef4444' : '#f59e0b',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '12px',
+            cursor: 'pointer'
+          }}>
+            {alert.action}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default AlertsWidget;

--- a/src/modules/dashboard/components/AlertsWidget.test.jsx
+++ b/src/modules/dashboard/components/AlertsWidget.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AlertsWidget from './AlertsWidget';
+
+test('renders alerts when out of stock products exist', () => {
+  render(
+    <AlertsWidget
+      globalProducts={[{ stock: 0 }]}
+      credits={[]}
+      showAlerts={true}
+      setShowAlerts={() => {}}
+      isDark={false}
+    />
+  );
+  expect(screen.getByText('Alertes Importantes')).toBeInTheDocument();
+});

--- a/src/modules/dashboard/components/DataManagerWidget.jsx
+++ b/src/modules/dashboard/components/DataManagerWidget.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { Database, Settings } from 'lucide-react';
+
+const DataManagerWidget = ({
+  showDataManager,
+  setShowDataManager,
+  globalProducts = [],
+  salesHistory = [],
+  customers = [],
+  credits = [],
+  appSettings = {},
+  clearAllData,
+  isDark
+}) => (
+  <div style={{
+    background: isDark ? '#2d3748' : 'white',
+    padding: '24px',
+    borderRadius: '12px',
+    boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+    border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`
+  }}>
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: '15px'
+    }}>
+      <h3 style={{
+        fontSize: '18px',
+        fontWeight: 'bold',
+        color: isDark ? '#f7fafc' : '#2d3748',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        margin: 0
+      }}>
+        <Database size={20} />
+        Sauvegarde & Synchronisation Cloud
+      </h3>
+      <button
+        onClick={() => setShowDataManager(!showDataManager)}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: isDark ? '#a0aec0' : '#64748b',
+          cursor: 'pointer',
+          padding: '4px'
+        }}
+      >
+        <Settings size={16} />
+      </button>
+    </div>
+
+    {showDataManager && (
+      <div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '10px', flexWrap: 'wrap' }}>
+          <button
+            onClick={() => {
+              const dataToExport = {
+                timestamp: new Date().toISOString(),
+                products: globalProducts,
+                sales: salesHistory,
+                customers,
+                credits,
+                settings: appSettings
+              };
+
+              const blob = new Blob([JSON.stringify(dataToExport, null, 2)], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `pos-backup-${new Date().toISOString().split('T')[0]}.json`;
+              document.body.appendChild(a);
+              a.click();
+              document.body.removeChild(a);
+              URL.revokeObjectURL(url);
+            }}
+            style={{
+              padding: '8px 16px',
+              background: '#10b981',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '14px'
+            }}
+          >
+            💾 Télécharger Sauvegarde
+          </button>
+
+          <button
+            onClick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = '.json';
+              input.onchange = (e) => {
+                const file = e.target.files[0];
+                if (!file) return;
+
+                const reader = new FileReader();
+                reader.onload = () => {
+                  try {
+                    JSON.parse(reader.result);
+                    alert("📄 Fichier valide ! Fonctionnalité d'import en cours de développement...");
+                  } catch (error) {
+                    alert('❌ Fichier de sauvegarde invalide');
+                  }
+                };
+                reader.readAsText(file);
+              };
+              input.click();
+            }}
+            style={{
+              padding: '8px 16px',
+              background: '#3b82f6',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '14px'
+            }}
+          >
+            📤 Importer Sauvegarde
+          </button>
+
+          <button
+            onClick={clearAllData}
+            style={{
+              padding: '8px 16px',
+              background: '#ef4444',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '14px'
+            }}
+          >
+            🗑️ Effacer Toutes les Données
+          </button>
+        </div>
+        <p style={{ fontSize: '12px', color: isDark ? '#a0aec0' : '#718096', marginTop: '10px', margin: 0 }}>
+          💡 Les données sont automatiquement sauvegardées localement dans votre navigateur
+        </p>
+      </div>
+    )}
+  </div>
+);
+
+export default DataManagerWidget;

--- a/src/modules/dashboard/components/DataManagerWidget.test.jsx
+++ b/src/modules/dashboard/components/DataManagerWidget.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DataManagerWidget from './DataManagerWidget';
+
+test('renders data manager widget heading', () => {
+  render(
+    <DataManagerWidget
+      showDataManager={true}
+      setShowDataManager={() => {}}
+      globalProducts={[]}
+      salesHistory={[]}
+      customers={[]}
+      credits={[]}
+      appSettings={{}}
+      clearAllData={() => {}}
+      isDark={false}
+    />
+  );
+  expect(screen.getByText(/Sauvegarde/)).toBeInTheDocument();
+});

--- a/src/modules/dashboard/components/MetricCard.jsx
+++ b/src/modules/dashboard/components/MetricCard.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ArrowUp, ArrowDown, Activity } from 'lucide-react';
+
+const MetricCard = ({ title, value, change, icon: Icon, color, format = 'number', isDark, currency }) => {
+  const safeToLocaleString = (val) => (val || 0).toLocaleString();
+  const formatValue = (val) => {
+    if (format === 'currency') {
+      return `${safeToLocaleString(val)} ${currency || 'FCFA'}`;
+    }
+    return safeToLocaleString(val);
+  };
+
+  const changeColor = change > 0 ? '#10b981' : change < 0 ? '#ef4444' : '#6b7280';
+  const ChangeIcon = change > 0 ? ArrowUp : change < 0 ? ArrowDown : Activity;
+
+  return (
+    <div style={{
+      background: isDark ? '#2d3748' : 'white',
+      padding: '24px',
+      borderRadius: '12px',
+      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
+        {Icon && <Icon size={24} color={color} />}
+        <h3 style={{ fontSize: '16px', fontWeight: '600', color: isDark ? '#f7fafc' : '#2d3748', margin: 0 }}>
+          {title}
+        </h3>
+      </div>
+
+      <div style={{ marginBottom: '12px' }}>
+        <div style={{ fontSize: '28px', fontWeight: 'bold', color: isDark ? '#f7fafc' : '#2d3748', marginBottom: '4px' }}>
+          {formatValue(value)}
+        </div>
+      </div>
+
+      {change !== 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '14px', color: changeColor }}>
+          <ChangeIcon size={16} />
+          <span>{Math.abs(change)}% vs période précédente</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MetricCard;

--- a/src/modules/dashboard/components/MetricCard.test.jsx
+++ b/src/modules/dashboard/components/MetricCard.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MetricCard from './MetricCard';
+
+test('renders MetricCard with title and value', () => {
+  const Dummy = () => <svg />;
+  render(
+    <MetricCard
+      title="Test"
+      value={100}
+      change={0}
+      icon={Dummy}
+      color="#000"
+      isDark={false}
+      currency="FCFA"
+    />
+  );
+  expect(screen.getByText('Test')).toBeInTheDocument();
+  expect(screen.getByText(/100/)).toBeInTheDocument();
+});

--- a/src/modules/dashboard/components/TopProductsWidget.jsx
+++ b/src/modules/dashboard/components/TopProductsWidget.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Target } from 'lucide-react';
+
+const TopProductsWidget = ({ globalProducts = [], salesHistory = [], isDark, currency }) => {
+  const safeToLocaleString = (val) => (val || 0).toLocaleString();
+
+  const topProducts = globalProducts.map(product => {
+    const totalSold = salesHistory.reduce((sum, sale) => {
+      const item = (sale.items || []).find(i => i.id === product.id);
+      return sum + (item ? (item.quantity || 0) : 0);
+    }, 0);
+    const totalRevenue = totalSold * (product.price || 0);
+    return { ...product, totalSold, totalRevenue };
+  })
+  .filter(p => p.totalSold > 0)
+  .sort((a, b) => b.totalRevenue - a.totalRevenue)
+  .slice(0, 5);
+
+  return (
+    <div style={{
+      background: isDark ? '#2d3748' : 'white',
+      padding: '24px',
+      borderRadius: '12px',
+      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`
+    }}>
+      <h3 style={{
+        fontSize: '18px',
+        fontWeight: 'bold',
+        color: isDark ? '#f7fafc' : '#2d3748',
+        marginBottom: '16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px'
+      }}>
+        <Target size={20} />
+        Produits Populaires
+      </h3>
+
+      {topProducts.length === 0 ? (
+        <div style={{ textAlign: 'center', color: isDark ? '#a0aec0' : '#64748b', fontSize: '14px', padding: '20px' }}>
+          Aucune vente enregistrée
+        </div>
+      ) : (
+        <div>
+          {topProducts.map((product, index) => (
+            <div
+              key={product.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                padding: '12px 0',
+                borderBottom: index < topProducts.length - 1 ? `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}` : 'none'
+              }}
+            >
+              <div>
+                <div style={{ fontWeight: '600', color: isDark ? '#f7fafc' : '#2d3748', fontSize: '14px' }}>
+                  {product.name}
+                </div>
+                <div style={{ fontSize: '12px', color: isDark ? '#a0aec0' : '#64748b' }}>
+                  {product.totalSold} vendus
+                </div>
+              </div>
+
+              <div style={{ textAlign: 'right' }}>
+                <div style={{ fontWeight: 'bold', color: '#3b82f6', fontSize: '14px' }}>
+                  {safeToLocaleString(product.totalRevenue)} {currency || 'FCFA'}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopProductsWidget;

--- a/src/modules/dashboard/components/TopProductsWidget.test.jsx
+++ b/src/modules/dashboard/components/TopProductsWidget.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TopProductsWidget from './TopProductsWidget';
+
+test('renders top products', () => {
+  const products = [{ id: 1, name: 'Prod', price: 10 }];
+  const sales = [{ items: [{ id: 1, quantity: 2 }] }];
+  render(
+    <TopProductsWidget
+      globalProducts={products}
+      salesHistory={sales}
+      isDark={false}
+      currency="FCFA"
+    />
+  );
+  expect(screen.getByText('Prod')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- extract dashboard widgets into dedicated component files
- simplify DashboardModule to assemble reusable widgets
- add basic rendering tests for dashboard widgets

## Testing
- `npm test -- src/modules/dashboard/components/MetricCard.test.jsx` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae298654e0832dbf175f9815082bfc