### PR TITLE
feat: enable module navigation from dashboard alerts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,7 +77,7 @@ function AppContent() {
     }
     switch(activeModule) {
       case 'dashboard':
-        return <DashboardModule />;
+        return <DashboardModule onNavigate={setActiveModule} />;
       case 'sales':
         return <SalesModule />;
       case 'stocks':
@@ -97,7 +97,7 @@ function AppContent() {
       case 'returns':
         return <ReturnsModule />;
       default:
-        return <DashboardModule />;
+        return <DashboardModule onNavigate={setActiveModule} />;
     }
   };
 

--- a/src/modules/dashboard/DashboardModule.jsx
+++ b/src/modules/dashboard/DashboardModule.jsx
@@ -7,7 +7,7 @@ import DataManagerWidget from './components/DataManagerWidget';
 import { useApp } from '../../contexts/AppContext'; // ✅ CORRECTION CRITIQUE
 import styles from './DashboardModule.module.css';
 
-const DashboardModule = () => {
+const DashboardModule = ({ onNavigate }) => {
   const {
     globalProducts,
     customers,
@@ -127,6 +127,7 @@ const DashboardModule = () => {
         showAlerts={showAlerts}
         setShowAlerts={setShowAlerts}
         isDark={isDark}
+        onNavigate={onNavigate}
       />
 
       {/* Métriques principales avec comparaison */}

--- a/src/modules/dashboard/components/AlertsWidget.jsx
+++ b/src/modules/dashboard/components/AlertsWidget.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AlertTriangle, Package, Clock, Bell } from 'lucide-react';
 
-const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAlerts, isDark }) => {
+const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAlerts, isDark, onNavigate = () => {} }) => {
   const lowStockProducts = globalProducts.filter(p => (p.stock || 0) > 0 && (p.stock || 0) <= (p.minStock || 5));
   const outOfStockProducts = globalProducts.filter(p => (p.stock || 0) === 0);
   const overdueCredits = credits.filter(c => {
@@ -18,7 +18,8 @@ const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAl
       icon: AlertTriangle,
       title: 'Ruptures de Stock',
       message: `${outOfStockProducts.length} produit(s) en rupture`,
-      action: 'Voir Stocks'
+      action: 'Voir Stocks',
+      onClick: () => onNavigate('stocks')
     });
   }
 
@@ -28,7 +29,8 @@ const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAl
       icon: Package,
       title: 'Stock Faible',
       message: `${lowStockProducts.length} produit(s) en stock faible`,
-      action: 'Réapprovisionner'
+      action: 'Réapprovisionner',
+      onClick: () => onNavigate('stocks')
     });
   }
 
@@ -38,7 +40,8 @@ const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAl
       icon: Clock,
       title: 'Crédits en Retard',
       message: `${overdueCredits.length} crédit(s) en retard`,
-      action: 'Voir Crédits'
+      action: 'Voir Crédits',
+      onClick: () => onNavigate('credits')
     });
   }
 
@@ -105,7 +108,7 @@ const AlertsWidget = ({ globalProducts = [], credits = [], showAlerts, setShowAl
               {alert.message}
             </div>
           </div>
-          <button style={{
+          <button onClick={alert.onClick} style={{
             padding: '6px 12px',
             background: alert.type === 'error' ? '#ef4444' : '#f59e0b',
             color: 'white',

--- a/src/modules/dashboard/components/AlertsWidget.test.jsx
+++ b/src/modules/dashboard/components/AlertsWidget.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import AlertsWidget from './AlertsWidget';
 
 test('renders alerts when out of stock products exist', () => {
@@ -10,7 +10,24 @@ test('renders alerts when out of stock products exist', () => {
       showAlerts={true}
       setShowAlerts={() => {}}
       isDark={false}
+      onNavigate={() => {}}
     />
   );
   expect(screen.getByText('Alertes Importantes')).toBeInTheDocument();
+});
+
+test('calls onNavigate with stocks when clicking alert', () => {
+  const handleNavigate = jest.fn();
+  render(
+    <AlertsWidget
+      globalProducts={[{ stock: 0 }]}
+      credits={[]}
+      showAlerts={true}
+      setShowAlerts={() => {}}
+      isDark={false}
+      onNavigate={handleNavigate}
+    />
+  );
+  fireEvent.click(screen.getByText('Voir Stocks'));
+  expect(handleNavigate).toHaveBeenCalledWith('stocks');
 });


### PR DESCRIPTION
## Summary
- pass navigation callback to dashboard module from App
- wire dashboard alerts to navigate to related modules
- add test confirming alert navigation callback

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2dec64e8832d9d38ccceb3960f6c