### PR TITLE
feat: support importing validated backups

### DIFF
--- a/src/modules/dashboard/DashboardModule.jsx
+++ b/src/modules/dashboard/DashboardModule.jsx
@@ -17,7 +17,12 @@ const DashboardModule = ({ onNavigate }) => {
     clearAllData,
     credits,
     viewMode,
-    getCurrentStore
+    getCurrentStore,
+    setGlobalProducts,
+    setSalesHistory,
+    setCustomers,
+    setCredits,
+    setAppSettings
   } = useApp(); // ✅ CORRECTION CRITIQUE
   
   const [selectedPeriod, setSelectedPeriod] = useState('today');
@@ -118,6 +123,11 @@ const DashboardModule = ({ onNavigate }) => {
         appSettings={appSettings}
         clearAllData={clearAllData}
         isDark={isDark}
+        setGlobalProducts={setGlobalProducts}
+        setSalesHistory={setSalesHistory}
+        setCustomers={setCustomers}
+        setCredits={setCredits}
+        setAppSettings={setAppSettings}
       />
 
       {/* Alertes */}

--- a/src/modules/dashboard/components/DataManagerWidget.test.jsx
+++ b/src/modules/dashboard/components/DataManagerWidget.test.jsx
@@ -14,6 +14,11 @@ test('renders data manager widget heading', () => {
       appSettings={{}}
       clearAllData={() => {}}
       isDark={false}
+      setGlobalProducts={() => {}}
+      setSalesHistory={() => {}}
+      setCustomers={() => {}}
+      setCredits={() => {}}
+      setAppSettings={() => {}}
     />
   );
   expect(screen.getByText(/Sauvegarde/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- handle JSON backup import with validation and automatic backup
- pass state setters to data manager widget
- update widget tests for new props

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f19c3d4832db34d3d96458e760c