### PR TITLE
feat: add collapsible cloud sync panel

### DIFF
--- a/src/components/CloudSyncPanel.jsx
+++ b/src/components/CloudSyncPanel.jsx
@@ -18,6 +18,7 @@ export const CloudSyncPanel = () => {
   const [showCloudSetup, setShowCloudSetup] = useState(false);
   const [credentials, setCredentials] = useState({ email: '', password: '' });
   const [isNewAccount, setIsNewAccount] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
 
   const handleEnableCloud = async () => {
     const result = await enableCloud(credentials.email, credentials.password, isNewAccount);
@@ -48,9 +49,21 @@ export const CloudSyncPanel = () => {
     }
   };
 
+  if (isCollapsed) {
+    return (
+      <div className={styles.collapsed} onClick={() => setIsCollapsed(false)}>
+        <span className={styles.statusIcon}>☁️</span>
+        <span className={styles.toggle}>⬇️</span>
+      </div>
+    );
+  }
+
   return (
-    <div className={styles.panel}>
-      <h3 className={styles.title}>Sauvegarde & Synchronisation Cloud</h3>
+    <div className={styles.expanded}>
+      <div className={styles.header}>
+        <h3 className={styles.title}>Sauvegarde & Synchronisation Cloud</h3>
+        <span className={styles.toggle} onClick={() => setIsCollapsed(true)}>⬆️</span>
+      </div>
 
       {/* Status */}
       <div className={styles.status}>

--- a/src/components/CloudSyncPanel.module.css
+++ b/src/components/CloudSyncPanel.module.css
@@ -1,4 +1,15 @@
-.panel {
+.collapsed {
+  background: var(--color-surface);
+  padding: 8px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.expanded {
   background: var(--color-surface);
   padding: 20px;
   border-radius: 8px;
@@ -36,6 +47,18 @@
 .statusSub {
   font-size: 12px;
   color: var(--color-text-secondary);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 15px;
+}
+
+.toggle {
+  cursor: pointer;
+  font-size: 18px;
 }
 
 .button {

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Navigation from './Navigation';
+import { CloudSyncPanel } from '../CloudSyncPanel';
 
 /**
  * Simple header component with optional title and navigation links.
@@ -8,8 +9,11 @@ const Header = ({ title = '', links = [], children }) => {
   return (
     <header style={styles.header}>
       {title && <h1 style={styles.title}>{title}</h1>}
-      {links.length > 0 && <Navigation links={links} />}
-      {children}
+      <div style={styles.right}>
+        {links.length > 0 && <Navigation links={links} />}
+        {children}
+        <CloudSyncPanel />
+      </div>
     </header>
   );
 };
@@ -26,6 +30,11 @@ const styles = {
   title: {
     margin: 0,
     fontSize: '1.25rem'
+  },
+  right: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem'
   }
 };
 


### PR DESCRIPTION
## Summary
- allow CloudSyncPanel to collapse to a cloud icon with toggle arrow
- split panel styling into collapsed and expanded variants and integrate into header

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae32579b2c832d8cce56f944e2b4b5