### PR TITLE
feat: add sales chart component

### DIFF
--- a/src/modules/dashboard/DashboardModule.jsx
+++ b/src/modules/dashboard/DashboardModule.jsx
@@ -4,6 +4,7 @@ import MetricCard from './components/MetricCard';
 import AlertsWidget from './components/AlertsWidget';
 import TopProductsWidget from './components/TopProductsWidget';
 import DataManagerWidget from './components/DataManagerWidget';
+import SalesChart from './SalesChart';
 import { useApp } from '../../contexts/AppContext'; // ✅ CORRECTION CRITIQUE
 import styles from './DashboardModule.module.css';
 
@@ -198,7 +199,7 @@ const DashboardModule = ({ onNavigate }) => {
           currency={appSettings?.currency}
         />
 
-        <MetricCard
+      <MetricCard
           title="Clients Fidèles"
           value={stats?.totalCustomers || 0}
           change={0}
@@ -208,6 +209,10 @@ const DashboardModule = ({ onNavigate }) => {
           currency={appSettings?.currency}
         />
       </div>
+      <SalesChart
+        salesHistory={salesHistory}
+        selectedPeriod={selectedPeriod}
+      />
 
       {/* Widgets d'analyse */}
       <div className={styles.chartsGrid}>

--- a/src/modules/dashboard/SalesChart.jsx
+++ b/src/modules/dashboard/SalesChart.jsx
@@ -1,0 +1,144 @@
+import React, { useRef, useEffect } from 'react';
+
+// Map for day and month names used in labels
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Regroupe l'historique des ventes selon la période sélectionnée
+ * et retourne les labels et les totaux correspondants.
+ */
+export const groupSalesByPeriod = (salesHistory = [], selectedPeriod = 'today', now = new Date()) => {
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+
+  const periods = {
+    today: { start: startOfToday },
+    week: { start: new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000) }, // 7 derniers jours
+    month: { start: new Date(now.getFullYear(), now.getMonth(), 1) },
+    year: { start: new Date(now.getFullYear(), 0, 1) }
+  };
+
+  const { start } = periods[selectedPeriod] || periods.today;
+  const groups = {};
+
+  salesHistory.forEach(sale => {
+    const date = new Date(sale.date);
+    if (isNaN(date) || date < start || date > now) return;
+
+    let key;
+    switch (selectedPeriod) {
+      case 'today':
+        key = `${date.getHours()}h`;
+        break;
+      case 'week':
+        key = `${DAY_NAMES[date.getDay()]} ${date.getDate()}`;
+        break;
+      case 'month':
+        key = `W${Math.floor((date.getDate() - 1) / 7) + 1}`;
+        break;
+      case 'year':
+      default:
+        key = MONTH_NAMES[date.getMonth()];
+        break;
+    }
+
+    groups[key] = (groups[key] || 0) + (sale.total || 0);
+  });
+
+  let labels = [];
+
+  switch (selectedPeriod) {
+    case 'today':
+      labels = Array.from({ length: 24 }, (_, i) => `${i}h`);
+      break;
+    case 'week':
+      // Les 7 derniers jours
+      for (let i = 6; i >= 0; i--) {
+        const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+        labels.push(`${DAY_NAMES[d.getDay()]} ${d.getDate()}`);
+      }
+      break;
+    case 'month':
+      const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+      const weekCount = Math.ceil(lastDay / 7);
+      for (let i = 1; i <= weekCount; i++) {
+        labels.push(`W${i}`);
+      }
+      break;
+    case 'year':
+    default:
+      labels = MONTH_NAMES;
+      break;
+  }
+
+  const data = labels.map(label => groups[label] || 0);
+
+  return { labels, data };
+};
+
+/**
+ * Affiche un graphique simple en utilisant la balise canvas
+ * représentant les ventes pour la période sélectionnée.
+ */
+const SalesChart = ({ salesHistory, selectedPeriod }) => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const { labels, data } = groupSalesByPeriod(salesHistory, selectedPeriod);
+    const ctx = canvas.getContext('2d');
+
+    const width = canvas.width;
+    const height = canvas.height;
+    const padding = 30;
+
+    ctx.clearRect(0, 0, width, height);
+
+    // Axes
+    ctx.strokeStyle = '#ccc';
+    ctx.beginPath();
+    ctx.moveTo(padding, padding);
+    ctx.lineTo(padding, height - padding);
+    ctx.lineTo(width - padding, height - padding);
+    ctx.stroke();
+
+    const max = Math.max(...data, 1);
+    const stepX = (width - padding * 2) / (data.length - 1 || 1);
+    const chartHeight = height - padding * 2;
+
+    // Ligne des données
+    ctx.strokeStyle = '#3b82f6';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    data.forEach((val, i) => {
+      const x = padding + i * stepX;
+      const y = padding + chartHeight - (val / max) * chartHeight;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // Points
+    ctx.fillStyle = '#3b82f6';
+    data.forEach((val, i) => {
+      const x = padding + i * stepX;
+      const y = padding + chartHeight - (val / max) * chartHeight;
+      ctx.beginPath();
+      ctx.arc(x, y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    });
+
+  }, [salesHistory, selectedPeriod]);
+
+  return (
+    <div style={{ width: '100%', marginTop: '2rem' }}>
+      <canvas ref={canvasRef} width={800} height={300} style={{ width: '100%' }} />
+    </div>
+  );
+};
+
+export default SalesChart;
+

--- a/src/modules/dashboard/SalesChart.test.js
+++ b/src/modules/dashboard/SalesChart.test.js
@@ -1,0 +1,52 @@
+import { groupSalesByPeriod } from './SalesChart';
+
+describe('groupSalesByPeriod', () => {
+  const now = new Date('2024-05-15T12:00:00Z');
+  const salesHistory = [
+    { date: '2024-05-15T10:00:00Z', total: 100 },
+    { date: '2024-05-15T11:00:00Z', total: 50 },
+    { date: '2024-05-14T09:00:00Z', total: 75 },
+    { date: '2024-05-01T12:00:00Z', total: 120 },
+    { date: '2024-05-08T12:00:00Z', total: 80 },
+    { date: '2024-03-05T12:00:00Z', total: 200 }
+  ];
+
+  test('groups by hour for today', () => {
+    const { labels, data } = groupSalesByPeriod(salesHistory, 'today', now);
+    expect(labels.length).toBe(24);
+    const idx10 = labels.indexOf('10h');
+    const idx11 = labels.indexOf('11h');
+    expect(data[idx10]).toBe(100);
+    expect(data[idx11]).toBe(50);
+  });
+
+  test('groups by day for week', () => {
+    const { labels, data } = groupSalesByPeriod(salesHistory, 'week', now);
+    expect(labels.length).toBe(7);
+    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const yesterday = new Date('2024-05-14T00:00:00Z');
+    const label = `${dayNames[yesterday.getUTCDay()]} ${yesterday.getUTCDate()}`;
+    const idx = labels.indexOf(label);
+    expect(data[idx]).toBe(75);
+  });
+
+  test('groups by week for month', () => {
+    const { labels, data } = groupSalesByPeriod(salesHistory, 'month', now);
+    expect(labels.includes('W1')).toBe(true);
+    expect(labels.includes('W3')).toBe(true);
+    const idxW1 = labels.indexOf('W1');
+    const idxW3 = labels.indexOf('W3');
+    expect(data[idxW1]).toBe(120);
+    expect(data[idxW3]).toBe(225);
+  });
+
+  test('groups by month for year', () => {
+    const { labels, data } = groupSalesByPeriod(salesHistory, 'year', now);
+    expect(labels.length).toBe(12);
+    const idxMar = labels.indexOf('Mar');
+    const idxMay = labels.indexOf('May');
+    expect(data[idxMar]).toBe(200);
+    expect(data[idxMay]).toBe(425);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement SalesChart component with canvas-based line chart
- integrate SalesChart into dashboard and add period grouping logic
- cover grouping logic with unit tests

## Testing
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae34a7655c832dbd951e40f35d37d2