### PR TITLE
feat: show margin percentage

### DIFF
--- a/src/modules/dashboard/DashboardModule.jsx
+++ b/src/modules/dashboard/DashboardModule.jsx
@@ -79,6 +79,8 @@ const DashboardModule = ({ onNavigate }) => {
     const marginGrowth = previousMargin > 0 ?
       ((currentMargin - previousMargin) / previousMargin * 100) : 0;
 
+    const marginPct = currentRevenue > 0 ? (currentMargin / currentRevenue) * 100 : 0;
+
     const currentTransactions = currentSales.length;
     const previousTransactions = previousSales.length;
     const transactionGrowth = previousTransactions > 0 ?
@@ -92,6 +94,7 @@ const DashboardModule = ({ onNavigate }) => {
       currentMargin,
       previousMargin,
       marginGrowth: parseFloat(marginGrowth.toFixed(1)),
+      marginPct: parseFloat(marginPct.toFixed(1)),
       currentTransactions,
       previousTransactions,
       transactionGrowth: parseFloat(transactionGrowth.toFixed(1))
@@ -172,6 +175,7 @@ const DashboardModule = ({ onNavigate }) => {
           title={`Marge brute - ${dashboardMetrics.periodLabel}`}
           value={dashboardMetrics.currentMargin}
           change={dashboardMetrics.marginGrowth}
+          marginPct={dashboardMetrics.marginPct}
           icon={BarChart3}
           color="#14b8a6"
           format="currency"

--- a/src/modules/dashboard/components/MetricCard.jsx
+++ b/src/modules/dashboard/components/MetricCard.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { ArrowUp, ArrowDown, Activity } from 'lucide-react';
 
-const MetricCard = ({ title, value, change, icon: Icon, color, format = 'number', isDark, currency }) => {
+const FormattedNumber = ({ value, style, minimumFractionDigits = 0 }) => {
+  const formatter = new Intl.NumberFormat(undefined, {
+    style,
+    minimumFractionDigits,
+    maximumFractionDigits: minimumFractionDigits,
+  });
+  const formatted = formatter.format(style === 'percent' ? value / 100 : value);
+  return <>{formatted}</>;
+};
+const MetricCard = ({ title, value, change, marginPct, icon: Icon, color, format = 'number', isDark, currency }) => {
   const safeToLocaleString = (val) => (val || 0).toLocaleString();
   const formatValue = (val) => {
     if (format === 'currency') {
@@ -32,6 +41,11 @@ const MetricCard = ({ title, value, change, icon: Icon, color, format = 'number'
         <div style={{ fontSize: '28px', fontWeight: 'bold', color: isDark ? '#f7fafc' : '#2d3748', marginBottom: '4px' }}>
           {formatValue(value)}
         </div>
+        {typeof marginPct === 'number' && (
+          <div style={{ fontSize: '14px', color: isDark ? '#a0aec0' : '#4a5568' }}>
+            (<FormattedNumber value={marginPct} style="percent" minimumFractionDigits={1} /> du CA)
+          </div>
+        )}
       </div>
 
       {change !== 0 && (

--- a/src/modules/dashboard/components/MetricCard.test.jsx
+++ b/src/modules/dashboard/components/MetricCard.test.jsx
@@ -18,3 +18,22 @@ test('renders MetricCard with title and value', () => {
   expect(screen.getByText('Test')).toBeInTheDocument();
   expect(screen.getByText(/100/)).toBeInTheDocument();
 });
+
+test('displays margin percentage when provided', () => {
+  const Dummy = () => <svg />;
+  render(
+    <MetricCard
+      title="Marge brute"
+      value={50}
+      change={0}
+      marginPct={25}
+      icon={Dummy}
+      color="#000"
+      isDark={false}
+      currency="FCFA"
+    />
+  );
+  expect(
+    screen.getByText((content) => content.includes('du CA') && content.includes('25'))
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- compute margin percentage alongside other dashboard metrics
- show margin share of revenue on the gross margin card
- cover new metric with a unit test

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae92415284832d84cb9941d82b7b11