### PR TITLE
Use floating button for collapsed cloud sync panel

### DIFF
--- a/src/components/CloudSyncPanel.jsx
+++ b/src/components/CloudSyncPanel.jsx
@@ -51,10 +51,9 @@ export const CloudSyncPanel = () => {
 
   if (isCollapsed) {
     return (
-      <div className={styles.collapsed} onClick={() => setIsCollapsed(false)}>
-        <span className={styles.statusIcon}>☁️</span>
-        <span className={styles.toggle}>⬇️</span>
-      </div>
+      <button className={styles.fab} onClick={() => setIsCollapsed(false)}>
+        ☁️
+      </button>
     );
   }
 

--- a/src/components/CloudSyncPanel.module.css
+++ b/src/components/CloudSyncPanel.module.css
@@ -1,12 +1,20 @@
-.collapsed {
-  background: var(--color-surface);
-  padding: 8px;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-  cursor: pointer;
-  display: inline-flex;
+
+.fab {
+  width: 40px;
+  height: 40px;
+  display: flex;
   align-items: center;
-  gap: 4px;
+  justify-content: center;
+  font-size: 20px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-info);
+  color: #fff;
+  cursor: pointer;
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
 .expanded {


### PR DESCRIPTION
## Summary
- Replace collapsed cloud sync div with a floating action button
- Add `.fab` styles and remove obsolete collapsed panel styles

## Testing
- `CI=true npm test` *(fails: groupSalesByPeriod groups by week for month, displays client and opens payment modal, DataManagerWidget heading, TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b18a8e29fc832db32c2d8a2844d13e