### PR TITLE
Replace CashRegister icon with ShoppingCart

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,6 @@ import {
   UserCog,
   RotateCcw,
   Receipt,
-  CashRegister
 } from 'lucide-react';
 import styles from './App.module.css';
 import LoadingSpinner from './components/common/LoadingSpinner';
@@ -213,7 +212,7 @@ function App() {
                       }`}
                       onClick={() => setActiveModule('pos')}
                     >
-                      <CashRegister size={18} />
+                      <ShoppingCart size={18} />
                       Point de Vente
                     </button>
                   )}


### PR DESCRIPTION
## Summary
- remove CashRegister import and use ShoppingCart icon for POS navigation

## Testing
- `npm run build`
- `npm test` *(fails: ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b330169b20832d9a414b8df0c05239