### PR TITLE
Format sales values in CFA without abbreviation

### DIFF
--- a/src/modules/dashboard/SalesChart.jsx
+++ b/src/modules/dashboard/SalesChart.jsx
@@ -13,6 +13,9 @@ import {
 const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+// Format a number into the CFA currency
+export const formatCFA = (value) => `${value.toLocaleString('fr-FR')} CFA`;
+
 /**
  * Regroupe l'historique des ventes selon la période sélectionnée
  * et retourne les labels et les totaux correspondants.
@@ -107,11 +110,11 @@ const SalesChart = ({ salesHistory, selectedPeriod }) => {
       <ResponsiveContainer>
         <BarChart data={chartData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
           <XAxis dataKey="label" />
-          <YAxis />
-          <Tooltip formatter={(value) => value} />
+          <YAxis tickFormatter={formatCFA} />
+          <Tooltip formatter={(value) => formatCFA(value)} />
           <Bar dataKey="margin" stackId="a" fill="#34d399" />
           <Bar dataKey="revenue" stackId="a" fill="#3b82f6">
-            <LabelList dataKey="revenue" position="top" />
+            <LabelList dataKey="revenue" position="top" formatter={formatCFA} />
           </Bar>
         </BarChart>
       </ResponsiveContainer>

--- a/src/modules/dashboard/SalesChart.test.js
+++ b/src/modules/dashboard/SalesChart.test.js
@@ -1,4 +1,4 @@
-import SalesChart, { groupSalesByPeriod } from './SalesChart';
+import SalesChart, { groupSalesByPeriod, formatCFA } from './SalesChart';
 
 describe('groupSalesByPeriod', () => {
   const now = new Date('2024-05-15T12:00:00Z');
@@ -105,6 +105,38 @@ describe('groupSalesByPeriod', () => {
     bars.forEach(bar => {
       expect(bar.props.stackId).toBe('a');
     });
+  });
+});
+
+describe('formatting', () => {
+  test('formatCFA returns full value without abbreviation', () => {
+    expect(formatCFA(1200)).toBe('1 200 CFA');
+    expect(formatCFA(1200).toLowerCase()).not.toContain('k');
+  });
+
+  test('SalesChart components use formatCFA', () => {
+    const element = SalesChart({ salesHistory: [], selectedPeriod: 'today' });
+    const findComponent = (node, typeName) => {
+      if (!node) return null;
+      if (Array.isArray(node)) {
+        for (const child of node) {
+          const found = findComponent(child, typeName);
+          if (found) return found;
+        }
+        return null;
+      }
+      if (node.type && node.type.name === typeName) return node;
+      if (node.props && node.props.children) return findComponent(node.props.children, typeName);
+      return null;
+    };
+
+    const yAxis = findComponent(element, 'YAxis');
+    const tooltip = findComponent(element, 'Tooltip');
+    const labelList = findComponent(element, 'LabelList');
+
+    expect(yAxis.props.tickFormatter(1000)).toBe('1 000 CFA');
+    expect(tooltip.props.formatter(1000)).toBe('1 000 CFA');
+    expect(labelList.props.formatter(1000)).toBe('1 000 CFA');
   });
 });
 


### PR DESCRIPTION
## Summary
- add `formatCFA` to render full CFA amounts
- apply formatter to YAxis, Tooltip and bar labels
- cover formatting with tests to avoid "k" abbreviation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca53e190832da99b7abde2842175