### PR TITLE
feat: format sales chart labels

### DIFF
--- a/src/modules/dashboard/SalesChart.jsx
+++ b/src/modules/dashboard/SalesChart.jsx
@@ -111,10 +111,16 @@ const SalesChart = ({ salesHistory, selectedPeriod }) => {
         <BarChart data={chartData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
           <XAxis dataKey="label" />
           <YAxis tickFormatter={formatCFA} />
-          <Tooltip formatter={(value) => formatCFA(value)} />
+          <Tooltip formatter={formatCFA} />
           <Bar dataKey="margin" stackId="a" fill="#34d399" />
           <Bar dataKey="revenue" stackId="a" fill="#3b82f6">
-            <LabelList dataKey="revenue" position="top" formatter={formatCFA} />
+            <LabelList
+              dataKey="revenue"
+              position="top"
+              content={(props) => (
+                <text {...props}>{formatCFA(props.value)}</text>
+              )}
+            />
           </Bar>
         </BarChart>
       </ResponsiveContainer>

--- a/src/modules/dashboard/SalesChart.test.js
+++ b/src/modules/dashboard/SalesChart.test.js
@@ -110,8 +110,8 @@ describe('groupSalesByPeriod', () => {
 
 describe('formatting', () => {
   test('formatCFA returns full value without abbreviation', () => {
-    expect(formatCFA(1200)).toBe('1 200 CFA');
-    expect(formatCFA(1200).toLowerCase()).not.toContain('k');
+    expect(formatCFA(123456)).toBe('123 456 CFA');
+    expect(formatCFA(123456).toLowerCase()).not.toContain('k');
   });
 
   test('SalesChart components use formatCFA', () => {
@@ -134,9 +134,17 @@ describe('formatting', () => {
     const tooltip = findComponent(element, 'Tooltip');
     const labelList = findComponent(element, 'LabelList');
 
-    expect(yAxis.props.tickFormatter(1000)).toBe('1 000 CFA');
-    expect(tooltip.props.formatter(1000)).toBe('1 000 CFA');
-    expect(labelList.props.formatter(1000)).toBe('1 000 CFA');
+    const yTick = yAxis.props.tickFormatter(123456);
+    const tip = tooltip.props.formatter(123456);
+    const labelElement = labelList.props.content({ value: 123456 });
+
+    expect(yTick).toBe('123 456 CFA');
+    expect(tip).toBe('123 456 CFA');
+    expect(labelElement.props.children).toBe('123 456 CFA');
+
+    expect(yTick.toLowerCase()).not.toContain('k');
+    expect(tip.toLowerCase()).not.toContain('k');
+    expect(labelElement.props.children.toLowerCase()).not.toContain('k');
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure sales chart tooltip and ticks use full CFA format
- show formatted CFA values atop bars
- test chart formatting without currency abbreviation

## Testing
- `npm test --silent` *(fails: affiche le client et ouvre la modale de paiement, renders data manager widget heading, Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e6e28d3c832d855cae54a9b3a424