### PR TITLE
Remove keyboard shortcut hints

### DIFF
--- a/src/modules/pos/Cart.jsx
+++ b/src/modules/pos/Cart.jsx
@@ -33,8 +33,7 @@ const Cart = ({ cart, setCart, updateQuantity, total, appSettings, isDark, onChe
         }}>
           <ShoppingCart size={40} />
           <p style={{ marginTop: '10px', fontSize: '14px' }}>
-            Panier vide<br/>
-            <span style={{ fontSize: '12px' }}>F2 pour rechercher</span>
+            Panier vide
           </p>
         </div>
       ) : (
@@ -150,7 +149,7 @@ const Cart = ({ cart, setCart, updateQuantity, total, appSettings, isDark, onChe
               }}
             >
               <CreditCard size={18} />
-              Payer (F3)
+              Payer
             </button>
           </div>
         </>

--- a/src/modules/pos/QuickSale.jsx
+++ b/src/modules/pos/QuickSale.jsx
@@ -72,7 +72,7 @@ const QuickSale = ({
           cursor: cart.length > 0 ? 'pointer' : 'not-allowed'
         }}
       >
-        Vider (F1)
+        Vider
       </button>
 
       <button
@@ -87,16 +87,8 @@ const QuickSale = ({
           cursor: 'pointer'
         }}
       >
-        Scanner (F4)
+        Scanner
       </button>
-
-      <span style={{
-        fontSize: '12px',
-        color: isDark ? '#a0aec0' : '#64748b',
-        alignSelf: 'center'
-      }}>
-        F2: Recherche | F3: Payer | F4: Scanner | Entrée: Ajouter
-      </span>
     </div>
   );
 
@@ -109,7 +101,7 @@ const QuickSale = ({
         <input
           id="product-search"
           type="text"
-          placeholder="Rechercher... (F2 pour focus, Entrée pour ajouter)"
+          placeholder="Rechercher..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           style={styles.searchBar}


### PR DESCRIPTION
## Summary
- remove function key hints from QuickSale actions and search input
- clean up Cart empty state and checkout button to avoid shortcut labels

## Testing
- `npm test -- --watchAll=false` *(fails: TestingLibraryElementError: Found multiple elements with the text: /Client/i; ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f91bb3dc832dab53e495e5a70901