### PR TITLE
feat(pos): add category filtering

### DIFF
--- a/src/modules/pos/POSModule.jsx
+++ b/src/modules/pos/POSModule.jsx
@@ -11,6 +11,7 @@ const POSModule = () => {
   const { globalProducts, processSale, customers, appSettings, addCredit } = useApp();
   const [cart, setCart] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('all');
   const [total, setTotal] = useState(0);
   const [selectedCustomer, setSelectedCustomer] = useState(1);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
@@ -21,6 +22,7 @@ const POSModule = () => {
   const [showScanner, setShowScanner] = useState(false);
 
   const products = globalProducts;
+  const categories = ['all', ...new Set(products.map(p => p.category).filter(Boolean))];
   const isDark = appSettings.darkMode;
 
   const { deviceType, isMobile } = useResponsive();
@@ -33,11 +35,14 @@ const POSModule = () => {
     setTotal(subtotal + tax);
   }, [cart, appSettings.taxRate]);
 
-  const filteredProducts = products.filter(product =>
-    product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    product.barcode?.includes(searchQuery)
-  ).slice(0, quickMode ? 12 : 20);
+  const filteredProducts = products.filter(product => {
+    const matchesSearch =
+      product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      product.sku.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      product.barcode?.includes(searchQuery);
+    const matchesCategory = selectedCategory === 'all' || product.category === selectedCategory;
+    return matchesSearch && matchesCategory;
+  }).slice(0, quickMode ? 12 : 20);
 
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -187,6 +192,9 @@ const POSModule = () => {
       <div style={styles.container}>
         <QuickSale
           products={filteredProducts}
+          categories={categories}
+          selectedCategory={selectedCategory}
+          setSelectedCategory={setSelectedCategory}
           addToCart={addToCart}
           searchQuery={searchQuery}
           setSearchQuery={setSearchQuery}

--- a/src/modules/pos/POSModule.test.js
+++ b/src/modules/pos/POSModule.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import POSModule from './POSModule';
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    globalProducts: [
+      { id: 1, name: 'Apple', category: 'Fruits', sku: 'A1', price: 100, stock: 10 },
+      { id: 2, name: 'Banana', category: 'Fruits', sku: 'B1', price: 150, stock: 10 },
+      { id: 3, name: 'Milk', category: 'Dairy', sku: 'M1', price: 200, stock: 10 }
+    ],
+    processSale: jest.fn(),
+    customers: [{ id: 1, name: 'Client Comptant', points: 0 }],
+    appSettings: { darkMode: false, taxRate: 0, currency: 'CFA' },
+    addCredit: jest.fn()
+  })
+}));
+
+jest.mock('../../components/ResponsiveComponents', () => ({
+  useResponsive: () => ({ deviceType: 'desktop', isMobile: false })
+}));
+
+test('filtre les produits par catégorie', () => {
+  render(<POSModule />);
+  expect(screen.getByText('Apple')).toBeInTheDocument();
+  expect(screen.getByText('Banana')).toBeInTheDocument();
+  expect(screen.getByText('Milk')).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText('Catégorie'), { target: { value: 'Fruits' } });
+
+  expect(screen.getByText('Apple')).toBeInTheDocument();
+  expect(screen.getByText('Banana')).toBeInTheDocument();
+  expect(screen.queryByText('Milk')).not.toBeInTheDocument();
+});

--- a/src/modules/pos/QuickSale.jsx
+++ b/src/modules/pos/QuickSale.jsx
@@ -4,6 +4,9 @@ import ProductGrid from './ProductGrid';
 
 const QuickSale = ({
   products,
+  categories = [],
+  selectedCategory = 'all',
+  setSelectedCategory = () => {},
   addToCart,
   searchQuery,
   setSearchQuery,
@@ -36,6 +39,16 @@ const QuickSale = ({
       border: `2px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
       borderRadius: '8px',
       fontSize: '16px',
+      marginBottom: '15px',
+      background: isDark ? '#374151' : 'white',
+      color: isDark ? '#f7fafc' : '#2d3748'
+    },
+    categorySelect: {
+      width: '100%',
+      padding: '12px 16px',
+      border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+      borderRadius: '8px',
+      fontSize: '14px',
       marginBottom: '15px',
       background: isDark ? '#374151' : 'white',
       color: isDark ? '#f7fafc' : '#2d3748'
@@ -95,6 +108,18 @@ const QuickSale = ({
   return (
     <div style={styles.productSection}>
       <QuickActions />
+
+      <select
+        aria-label="Catégorie"
+        value={selectedCategory}
+        onChange={(e) => setSelectedCategory(e.target.value)}
+        style={styles.categorySelect}
+      >
+        <option value="all">Toutes catégories</option>
+        {categories.filter(cat => cat !== 'all').map(category => (
+          <option key={category} value={category}>{category}</option>
+        ))}
+      </select>
 
       <div style={{ position: 'relative' }}>
         <Search style={{ position: 'absolute', left: '15px', top: '12px' }} size={20} color="#94a3b8" />


### PR DESCRIPTION
## Summary
- add category-based filtering in POSModule
- expose category selector in QuickSale
- cover selection filtering with a new test

## Testing
- `npm test -- src/modules/pos/POSModule.test.js --watchAll=false`
- `npm test -- --watchAll=false` *(fails: SalesModule.test.js, DataManagerWidget.test.jsx, App.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b88d2af50c832db49c6af7a58904dc