### PR TITLE
feat: compute suggested payment amounts

### DIFF
--- a/src/modules/pos/POSModule.jsx
+++ b/src/modules/pos/POSModule.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../../contexts/AppContext';
 import { useResponsive } from '../../components/ResponsiveComponents';
 import Cart from './Cart';
@@ -6,6 +6,7 @@ import PaymentModal from './PaymentModal';
 import QuickSale from './QuickSale';
 import Receipt from './Receipt';
 import BarcodeScanner from './BarcodeScanner';
+import { getSuggestedAmounts } from '../../utils/calculations';
 
 const POSModule = () => {
   const { globalProducts, processSale, customers, appSettings, addCredit } = useApp();
@@ -27,7 +28,7 @@ const POSModule = () => {
 
   const { deviceType, isMobile } = useResponsive();
 
-  const frequentAmounts = [500, 1000, 2000, 5000, 10000, 20000];
+  const frequentAmounts = useMemo(() => getSuggestedAmounts(total), [total]);
 
   useEffect(() => {
     const subtotal = cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);

--- a/src/modules/pos/SalesModule.jsx
+++ b/src/modules/pos/SalesModule.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../../contexts/AppContext';
 import { useResponsive } from '../../components/ResponsiveComponents';
 import Cart from './Cart';
@@ -6,6 +6,7 @@ import PaymentModal from './PaymentModal';
 import QuickSale from './QuickSale';
 import Receipt from './Receipt';
 import BarcodeScanner from './BarcodeScanner';
+import { getSuggestedAmounts } from '../../utils/calculations';
 
 const SalesModule = () => {
   const { globalProducts, processSale, customers, appSettings, addCredit } = useApp();
@@ -25,7 +26,7 @@ const SalesModule = () => {
 
   const { deviceType, isMobile } = useResponsive();
 
-  const frequentAmounts = [500, 1000, 2000, 5000, 10000, 20000];
+  const frequentAmounts = useMemo(() => getSuggestedAmounts(total), [total]);
 
   useEffect(() => {
     const subtotal = cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -1,0 +1,4 @@
+export function getSuggestedAmounts(total) {
+  const base = Math.ceil(total / 500) * 500; // arrondi au prochain 500
+  return [base, base + 500, base + 1000, base + 2000];
+}


### PR DESCRIPTION
## Summary
- add getSuggestedAmounts helper for rounded payment suggestions
- use getSuggestedAmounts in POSModule and SalesModule

## Testing
- `CI=true npm test --silent src/modules/pos/SalesModule.test.js src/modules/dashboard/components/DataManagerWidget.test.jsx src/App.test.js` *(fails: multiple elements with text in SalesModule and DataManagerWidget tests; TextEncoder is not defined in App.test)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e03118c832d8196dd775718cdc4