### PR TITLE
feat: export low stock products

### DIFF
--- a/src/modules/inventory/InventoryModule.test.js
+++ b/src/modules/inventory/InventoryModule.test.js
@@ -7,7 +7,7 @@ jest.mock('../../contexts/AppContext', () => ({
     inventories: { store1: [{ id: 1, name: 'Produit', category: 'A', stock: 10, costPrice: 5, price: 10 }] },
     setGlobalProducts: jest.fn(),
     addStock: jest.fn(),
-    appSettings: { darkMode: false },
+    appSettings: { darkMode: false, currency: 'FCFA' },
     salesHistory: [],
     currentStoreId: 'store1'
   })

--- a/src/utils/ExportUtils.js
+++ b/src/utils/ExportUtils.js
@@ -327,6 +327,15 @@ const addStockSheet = (workbook, XLSX, reportData, appSettings) => {
   
   const summarySheet = XLSX.utils.json_to_sheet(summaryData);
   XLSX.utils.book_append_sheet(workbook, summarySheet, 'Résumé Stocks');
+
+  const lowData = (stock.lowStockProducts || []).map(p => ({
+    'Produit': p.name,
+    'Stock': p.stock,
+    'Seuil Min': p.minStock,
+    'Prix Achat': `${p.costPrice?.toLocaleString()} ${appSettings.currency}`
+  }));
+  const lowSheet = XLSX.utils.json_to_sheet(lowData);
+  XLSX.utils.book_append_sheet(workbook, lowSheet, 'Stock Faible');
 };
 
 // Feuille des clients pour Excel


### PR DESCRIPTION
## Summary
- filter inventory view to show low stock items and allow exporting them to Excel
- include low stock sheet in stock exports
- add currency to inventory test setup

## Testing
- `CI=true npm test --silent` *(fails: ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b20b5678832d9daa60f9c222cad8