### PR TITLE
Preserve store selection across sessions

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -32,7 +32,9 @@ export function AuthProvider({ children }) {
             const stores = data.stores || [];
             setAllowedStores(stores);
             if (stores.length) {
-              setCurrentStoreId(stores[0]);
+              const saved = localStorage.getItem('pos_current_store');
+              const chosen = saved && stores.includes(saved) ? saved : stores[0];
+              setCurrentStoreId(chosen);
             }
           } else {
             setRole(null);


### PR DESCRIPTION
## Summary
- Respect the user's previously chosen store when authentication state changes
- Keep allowed store list and restore selection from `pos_current_store`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4d68ab4832da8a9ec966b1bfdff