### PR TITLE
Refactor inventory storage into catalog and per-store stock

### DIFF
--- a/src/modules/inventory/InventoryModule.jsx
+++ b/src/modules/inventory/InventoryModule.jsx
@@ -11,7 +11,7 @@ import TransferStock from './TransferStock';
 import { generateRealExcel } from '../../utils/ExportUtils';
 
 const InventoryModule = () => {
-  const { inventories, setGlobalProducts, addStock, appSettings, salesHistory, currentStoreId } = useApp(); // ✅ Utilise useApp
+  const { globalProducts, addStock, appSettings, salesHistory, currentStoreId, addProduct } = useApp();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [showAddModal, setShowAddModal] = useState(false);
@@ -26,7 +26,7 @@ const InventoryModule = () => {
   const isDark = appSettings.darkMode;
 
   // Produits du magasin courant
-  const products = (inventories[currentStoreId] || []);
+  const products = globalProducts || [];
 
   // Calculs statistiques mis à jour
   const stats = {
@@ -720,13 +720,13 @@ const InventoryModule = () => {
         category: newProduct.category || 'Divers',
         price: parseFloat(newProduct.price) || 0,
         costPrice: parseFloat(newProduct.costPrice) || 0,
-        stock: parseInt(newProduct.stock) || 0,
         minStock: parseInt(newProduct.minStock) || 5,
         barcode: newProduct.barcode || `${Date.now()}`,
         createdAt: new Date().toISOString()
       };
 
-      setGlobalProducts([...products, product]);
+      const initialStock = parseInt(newProduct.stock) || 0;
+      addProduct(product, initialStock);
       setShowAddModal(false);
       setNewProduct({
         name: '',

--- a/src/modules/inventory/InventoryModule.test.js
+++ b/src/modules/inventory/InventoryModule.test.js
@@ -4,8 +4,8 @@ import InventoryModule from './InventoryModule';
 
 jest.mock('../../contexts/AppContext', () => ({
   useApp: () => ({
-    inventories: { store1: [{ id: 1, name: 'Produit', category: 'A', stock: 10, costPrice: 5, price: 10 }] },
-    setGlobalProducts: jest.fn(),
+    globalProducts: [{ id: 1, name: 'Produit', category: 'A', stock: 10, costPrice: 5, price: 10 }],
+    addProduct: jest.fn(),
     addStock: jest.fn(),
     appSettings: { darkMode: false, currency: 'FCFA' },
     salesHistory: [],

--- a/src/modules/inventory/PhysicalInventory.jsx
+++ b/src/modules/inventory/PhysicalInventory.jsx
@@ -4,7 +4,7 @@ import { useApp } from '../../contexts/AppContext';
 import { addInventoryRecord } from '../../services/inventory.service';
 
 const PhysicalInventory = () => {
-  const { globalProducts, setGlobalProducts, appSettings } = useApp();
+  const { globalProducts, stockByStore, currentStoreId, setStockForStore, appSettings } = useApp();
   const [inventoryDate] = useState(new Date().toISOString().split('T')[0]);
   const [counts, setCounts] = useState({});
   const [notes, setNotes] = useState({});
@@ -48,12 +48,12 @@ const PhysicalInventory = () => {
     }
     
     if (window.confirm(`Voulez-vous appliquer ${differences.length} ajustement(s) ?`)) {
-      const updatedProducts = globalProducts.map(product => {
+      const newStock = { ...(stockByStore[currentStoreId] || {}) };
+      globalProducts.forEach(product => {
         const counted = parseInt(counts[product.id] || product.stock);
-        return { ...product, stock: counted };
+        newStock[product.id] = counted;
       });
-      
-      setGlobalProducts(updatedProducts);
+      setStockForStore(currentStoreId, newStock);
       
       // Sauvegarder l'historique de l'inventaire
       const inventoryRecord = {

--- a/src/modules/inventory/TransferStock.jsx
+++ b/src/modules/inventory/TransferStock.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useApp } from '../../contexts/AppContext';
 
 const TransferStock = () => {
-  const { stores, inventories, transferStock, currentStoreId } = useApp();
+  const { stores, productCatalog, stockByStore, transferStock, currentStoreId } = useApp();
   const [fromStore, setFromStore] = useState(currentStoreId);
   const [toStore, setToStore] = useState(stores.find(s => s.id !== currentStoreId)?.id || '');
   const [productId, setProductId] = useState('');
@@ -16,7 +16,10 @@ const TransferStock = () => {
     }
   };
 
-  const sourceProducts = inventories[fromStore] || [];
+  const sourceProducts = (productCatalog || []).map(p => ({
+    ...p,
+    stock: (stockByStore[fromStore] || {})[p.id] || 0
+  }));
 
   return (
     <div style={{ padding: '20px' }}>

--- a/src/modules/returns/ReturnsModule.test.js
+++ b/src/modules/returns/ReturnsModule.test.js
@@ -8,10 +8,10 @@ beforeEach(() => {
 });
 
 const Setup = () => {
-  const { setGlobalProducts } = useApp();
+  const { addProduct } = useApp();
   useEffect(() => {
-    setGlobalProducts([{ id: 1, name: 'Produit A', stock: 5 }]);
-  }, [setGlobalProducts]);
+    addProduct({ id: 1, name: 'Produit A', price: 0, costPrice: 0, minStock: 0, barcode: '1', category: '', createdAt: new Date().toISOString() }, 5);
+  }, [addProduct]);
   return <ReturnsModule />;
 };
 

--- a/src/services/inventory.service.js
+++ b/src/services/inventory.service.js
@@ -22,22 +22,23 @@ export async function addInventoryRecord(record) {
   return record;
 }
 
+// Stock par magasin { [productId]: quantity }
 export const loadInventory = (storeId) => {
-  if (!storeId) return [];
+  if (!storeId) return {};
   try {
-    const data = localStorage.getItem(`pos_${storeId}_products`);
-    return data ? JSON.parse(data) : [];
+    const data = localStorage.getItem(`pos_${storeId}_stock`);
+    return data ? JSON.parse(data) : {};
   } catch (err) {
-    console.warn('Erreur de chargement de l\'inventaire:', err);
-    return [];
+    console.warn("Erreur de chargement de l'inventaire:", err);
+    return {};
   }
 };
 
-export const saveInventory = (storeId, products) => {
+export const saveInventory = (storeId, stock) => {
   if (!storeId) return;
   try {
-    localStorage.setItem(`pos_${storeId}_products`, JSON.stringify(products));
+    localStorage.setItem(`pos_${storeId}_stock`, JSON.stringify(stock));
   } catch (err) {
-    console.warn('Erreur de sauvegarde de l\'inventaire:', err);
+    console.warn("Erreur de sauvegarde de l'inventaire:", err);
   }
 };


### PR DESCRIPTION
## Summary
- Separate product catalog from store stock with localStorage persistence
- Add context helper for registering products and initialize stock per store
- Update inventory components and services to work with new stock structure

## Testing
- `npm test` *(fails: TestingLibraryElementError, TextEncoder not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e9e6c408832dba6a81ab6d265977