### PR TITLE
Log restocks to inventory history

### DIFF
--- a/src/contexts/AppContext.test.js
+++ b/src/contexts/AppContext.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { AppProvider, useApp } from './AppContext';
+import { getInventoryHistory } from '../services/inventory.service';
+
+jest.mock('../services/api', () => ({
+  post: jest.fn().mockResolvedValue(null),
+  get: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn()
+}));
+
+test('enregistre un réapprovisionnement dans l\'historique', () => {
+  localStorage.clear();
+  localStorage.setItem('pos_current_store', 'wend-kuuni');
+  localStorage.setItem('pos_products_catalog', JSON.stringify([{ id: 1, name: 'Produit test' }]));
+
+  let addStockFn;
+  const Collector = () => {
+    const { addStock } = useApp();
+    addStockFn = addStock;
+    return null;
+  };
+
+  render(
+    <AppProvider>
+      <Collector />
+    </AppProvider>
+  );
+
+  act(() => {
+    addStockFn('wend-kuuni', 1, 5, 'Test restock');
+  });
+
+  const history = getInventoryHistory();
+  expect(history).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        storeId: 'wend-kuuni',
+        productId: 1,
+        quantity: 5,
+        reason: 'Test restock'
+      })
+    ])
+  );
+});

--- a/src/modules/inventory/InventoryModule.jsx
+++ b/src/modules/inventory/InventoryModule.jsx
@@ -22,6 +22,7 @@ const InventoryModule = () => {
   const [editingProduct, setEditingProduct] = useState(null);
   const [restockingProduct, setRestockingProduct] = useState(null);
   const [restockQuantity, setRestockQuantity] = useState('');
+  const [restockReason, setRestockReason] = useState('Réapprovisionnement manuel');
   const [activeTab, setActiveTab] = useState('overview');
   const [lowStockOnly, setLowStockOnly] = useState(false);
 
@@ -615,10 +616,16 @@ const InventoryModule = () => {
     const handleRestock = () => {
       const quantity = parseInt(restockQuantity);
       if (quantity > 0) {
-        addStock(currentStoreId, restockingProduct.id, quantity, 'Réapprovisionnement manuel');
+        addStock(
+          currentStoreId,
+          restockingProduct.id,
+          quantity,
+          restockReason || 'Réapprovisionnement'
+        );
         setShowRestockModal(false);
         setRestockingProduct(null);
         setRestockQuantity('');
+        setRestockReason('Réapprovisionnement manuel');
       }
     };
 
@@ -669,7 +676,25 @@ const InventoryModule = () => {
             }}
             autoFocus
           />
-          
+
+          <input
+            type="text"
+            placeholder="Raison du réapprovisionnement"
+            value={restockReason}
+            onChange={(e) => setRestockReason(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '12px',
+              border: `1px solid ${isDark ? '#4a5568' : '#e2e8f0'}`,
+              borderRadius: '8px',
+              background: isDark ? '#4a5568' : 'white',
+              color: isDark ? '#f7fafc' : '#2d3748',
+              fontSize: '14px',
+              marginBottom: '20px',
+              boxSizing: 'border-box'
+            }}
+          />
+
           <div style={{ display: 'flex', gap: '12px' }}>
             <button
               onClick={() => {


### PR DESCRIPTION
## Summary
- track stock additions and transfers in inventory history
- allow specifying a restock reason when adding stock
- test that restocks are saved to history

## Testing
- `npm test src/contexts/AppContext.test.js --watchAll=false`
- `npm test -- --watchAll=false` *(fails: DataManagerWidget.test.jsx, SalesModule.test.js, firebase config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9faaac0f8832da025098bfb604691