### PR TITLE
feat: add inventory history tab with stock movement filters

### DIFF
--- a/src/modules/inventory/StockMovements.jsx
+++ b/src/modules/inventory/StockMovements.jsx
@@ -8,10 +8,19 @@ const StockMovements = () => {
   const [endDate, setEndDate] = useState('');
 
   useEffect(() => {
-    const data = getInventoryHistory() || [];
-    // Tri du plus récent au plus ancien
-    data.sort((a, b) => new Date(b.date) - new Date(a.date));
-    setHistory(data);
+    const loadHistory = () => {
+      const data = [...(getInventoryHistory() || [])].sort(
+        (a, b) => new Date(b.date) - new Date(a.date)
+      );
+      setHistory(data);
+    };
+
+    // Chargement initial
+    loadHistory();
+
+    // Met à jour lorsqu'un autre onglet modifie l'historique
+    window.addEventListener('storage', loadHistory);
+    return () => window.removeEventListener('storage', loadHistory);
   }, []);
 
   const filteredHistory = history.filter((record) => {


### PR DESCRIPTION
## Summary
- load and display inventory history with filters and storage refresh
- expose History tab in inventory module to show movements
- ensure UI tests cover restock display

## Testing
- `npm test -- --watchAll=false` *(fails: EmployeesModule.test.js, SalesModule.test.js, DataManagerWidget.test.jsx)*
- `npm test -- src/modules/inventory/InventoryModule.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ba07a7c770832d8d9bb2ca5bf46bc0