### PR TITLE
Add manual import step for product Excel uploads

### DIFF
--- a/src/modules/inventory/ProductImportModal.jsx
+++ b/src/modules/inventory/ProductImportModal.jsx
@@ -9,6 +9,7 @@ const ProductImportModal = ({ isOpen, onClose }) => {
   const { inventories, setGlobalProducts, currentStoreId, appSettings } = useApp();
   const isDark = appSettings.darkMode;
   const [loading, setLoading] = useState(false);
+  const [file, setFile] = useState(null);
 
   if (!isOpen) return null;
 
@@ -19,8 +20,7 @@ const ProductImportModal = ({ isOpen, onClose }) => {
     XLSX.writeFile(wb, 'gabarit-import-produits.xlsx');
   };
 
-  const handleFile = (e) => {
-    const file = e.target.files[0];
+  const handleImport = () => {
     if (!file) return;
     setLoading(true);
 
@@ -57,6 +57,7 @@ const ProductImportModal = ({ isOpen, onClose }) => {
         console.error('Erreur lors de l\'importation:', err);
       } finally {
         setLoading(false);
+        setFile(null);
       }
     };
     reader.readAsBinaryString(file);
@@ -66,8 +67,20 @@ const ProductImportModal = ({ isOpen, onClose }) => {
     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
       <div style={{ background: isDark ? '#2d3748' : 'white', padding: '24px', borderRadius: '12px', width: '100%', maxWidth: '400px' }}>
         <h2 style={{ marginTop: 0, color: isDark ? '#f7fafc' : '#2d3748' }}>Importer Produits</h2>
-        <input type="file" accept=".xlsx,.xls" onChange={handleFile} disabled={loading} />
+        <input
+          type="file"
+          accept=".xlsx,.xls"
+          onChange={(e) => setFile(e.target.files[0] || null)}
+          disabled={loading}
+        />
         <div style={{ marginTop: '16px', display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={handleImport}
+            disabled={!file || loading}
+            style={{ padding: '8px 12px', background: '#38a169', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer', fontSize: '14px' }}
+          >
+            Importer
+          </button>
           <button
             onClick={handleTemplate}
             style={{ padding: '8px 12px', background: '#3182ce', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer', fontSize: '14px' }}


### PR DESCRIPTION
## Summary
- Store selected file in state in `ProductImportModal`
- Add explicit "Importer" action to parse selected file and update inventory

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb37846d5c832dbd428337e1e16a29