### PR TITLE
Fix product stock initialization on import

### DIFF
--- a/src/contexts/AppContext.jsx
+++ b/src/contexts/AppContext.jsx
@@ -136,9 +136,11 @@ export const AppProvider = ({ children }) => {
   const addProduct = (product, initialStock = 0) => {
     try {
       setProductCatalog(prev => [...prev, product]);
-      const storeStock = { ...(stockByStore[currentStoreId] || {}) };
-      storeStock[product.id] = initialStock;
-      setStockForStore(currentStoreId, storeStock);
+      setStockByStore(prev => {
+        const storeStock = { ...(prev[currentStoreId] || {}), [product.id]: initialStock };
+        saveInventory(currentStoreId, storeStock);
+        return { ...prev, [currentStoreId]: storeStock };
+      });
       return true;
     } catch (error) {
       console.error("Erreur lors de l'ajout de produit:", error);

--- a/src/contexts/AppContext.test.js
+++ b/src/contexts/AppContext.test.js
@@ -45,3 +45,36 @@ test('enregistre un réapprovisionnement dans l\'historique', () => {
     ])
   );
 });
+
+test("après l'import de plusieurs produits, chaque article conserve sa quantité", async () => {
+  localStorage.clear();
+  localStorage.setItem('pos_current_store', 'wend-kuuni');
+
+  let addProductFn;
+  let getGlobalProducts;
+  const Collector = () => {
+    const { addProduct, globalProducts } = useApp();
+    addProductFn = addProduct;
+    getGlobalProducts = () => globalProducts;
+    return null;
+  };
+
+  render(
+    <AppProvider>
+      <Collector />
+    </AppProvider>
+  );
+
+  await act(async () => {
+    addProductFn({ id: 1, name: 'Produit 1' }, 3);
+    addProductFn({ id: 2, name: 'Produit 2' }, 7);
+  });
+
+  const products = getGlobalProducts();
+  expect(products).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ id: 1, stock: 3 }),
+      expect.objectContaining({ id: 2, stock: 7 })
+    ])
+  );
+});


### PR DESCRIPTION
## Summary
- ensure addProduct uses functional state update to merge stock and persist inventory
- add regression test verifying multiple product imports keep correct quantities

## Testing
- `CI=true npm test -- src/contexts/AppContext.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb51f72fb8832d84ba6cfef3e7ca1e