### PR TITLE
feat: import stocks for multiple stores

### DIFF
--- a/src/modules/inventory/ProductImportModal.jsx
+++ b/src/modules/inventory/ProductImportModal.jsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import * as XLSX from 'xlsx';
 import { useApp } from '../../contexts/AppContext';
 
-const HEADERS = ['name', 'category', 'price', 'costPrice', 'minStock', 'stock'];
-
 const ProductImportModal = ({ isOpen, onClose }) => {
-  const { addProduct, appSettings } = useApp();
+  const { addProduct, addStock, appSettings, stores, currentStoreId } = useApp();
+  const baseHeaders = ['name', 'category', 'price', 'costPrice', 'minStock'];
+  const stockHeaders = stores.map(s => `stock_${s.code}`);
+  const HEADERS = [...baseHeaders, ...stockHeaders];
   const isDark = appSettings.darkMode;
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState(null);
@@ -35,6 +36,8 @@ const ProductImportModal = ({ isOpen, onClose }) => {
         const sheet = workbook.Sheets[workbook.SheetNames[0]];
         const rows = XLSX.utils.sheet_to_json(sheet, { header: HEADERS, range: 1, defval: '' });
 
+        const currentStore = stores.find(s => s.id === currentStoreId);
+
         for (let i = 0; i < rows.length; i++) {
           const row = rows[i];
           if (!row.name) continue;
@@ -45,15 +48,24 @@ const ProductImportModal = ({ isOpen, onClose }) => {
             price: parseFloat(row.price) || 0,
             costPrice: parseFloat(row.costPrice) || 0,
             minStock: parseInt(row.minStock) || 0,
-            stock: parseInt(row.stock) || 0,
             barcode: `${Date.now()}${Math.floor(Math.random() * 1000)}`
           };
-          addProduct(product, product.stock);
+
+          const currentStock = parseInt(row[`stock_${currentStore.code}`]) || 0;
+          addProduct(product, currentStock);
+
+          stores.forEach(store => {
+            if (store.id === currentStoreId) return;
+            const qty = parseInt(row[`stock_${store.code}`]) || 0;
+            if (qty > 0) {
+              addStock(store.id, product.id, qty, 'Import initial');
+            }
+          });
         }
 
         onClose();
       } catch (err) {
-        console.error('Erreur lors de l\'importation:', err);
+        console.error("Erreur lors de l'importation:", err);
       } finally {
         setLoading(false);
         setFile(null);

--- a/src/modules/inventory/ProductImportModal.test.js
+++ b/src/modules/inventory/ProductImportModal.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import * as XLSX from 'xlsx';
+import ProductImportModal from './ProductImportModal';
+
+const mockAddProduct = jest.fn();
+const mockAddStock = jest.fn();
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    addProduct: mockAddProduct,
+    addStock: mockAddStock,
+    appSettings: { darkMode: false },
+    stores: [
+      { id: 'wend-kuuni', code: 'WK001', name: 'Wend-Kuuni' },
+      { id: 'wend-yam', code: 'WY002', name: 'Wend-Yam' }
+    ],
+    currentStoreId: 'wend-kuuni'
+  })
+}));
+
+describe('ProductImportModal', () => {
+  beforeEach(() => {
+    mockAddProduct.mockClear();
+    mockAddStock.mockClear();
+  });
+
+  test('imports stocks for multiple stores', async () => {
+    const headers = ['name','category','price','costPrice','minStock','stock_WK001','stock_WY002'];
+    const data = [
+      headers,
+      ['Produit A','Cat','100','50','5','10','20']
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(data);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Produits');
+    const binary = XLSX.write(wb, { bookType: 'xlsx', type: 'binary' });
+
+    global.FileReader = class {
+      constructor() { this.onload = null; }
+      readAsBinaryString() { this.onload({ target: { result: binary } }); }
+    };
+
+    const file = new Blob(['']);
+    file.name = 'import.xlsx';
+
+    const { container, getByText } = render(<ProductImportModal isOpen={true} onClose={() => {}} />);
+    const input = container.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(getByText('Importer'));
+
+    await waitFor(() => expect(mockAddProduct).toHaveBeenCalledTimes(1));
+    expect(mockAddProduct.mock.calls[0][1]).toBe(10);
+    expect(mockAddStock).toHaveBeenCalledWith('wend-yam', expect.any(Number), 20, 'Import initial');
+  });
+});


### PR DESCRIPTION
## Summary
- build import headers dynamically from configured stores
- distribute imported stock across current and other stores
- test multi-store product import workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5268542c832d83e5a359140723f0