### PR TITLE
feat: allow removing products

### DIFF
--- a/src/contexts/AppContext.jsx
+++ b/src/contexts/AppContext.jsx
@@ -148,6 +148,29 @@ export const AppProvider = ({ children }) => {
     }
   };
 
+  const removeProduct = (id) => {
+    try {
+      setProductCatalog(prev => prev.filter(p => p.id !== id));
+      setStockByStore(prev => {
+        const updated = {};
+        Object.entries(prev).forEach(([storeId, stock]) => {
+          if (stock && Object.prototype.hasOwnProperty.call(stock, id)) {
+            const { [id]: _removed, ...rest } = stock;
+            updated[storeId] = rest;
+            saveInventory(storeId, rest);
+          } else {
+            updated[storeId] = stock;
+          }
+        });
+        return updated;
+      });
+      return true;
+    } catch (error) {
+      console.error('Erreur lors de la suppression du produit:', error);
+      return false;
+    }
+  };
+
   // Traiter une vente
   const processSale = (cart, paymentMethod, amountReceived, customerId = 1) => {
     try {
@@ -640,6 +663,7 @@ export const AppProvider = ({ children }) => {
     // Fonctions sécurisées
     processSale,
     addProduct,
+    removeProduct,
     setStockForStore,
     addStock,
     transferStock,

--- a/src/contexts/AppContext.test.js
+++ b/src/contexts/AppContext.test.js
@@ -78,3 +78,38 @@ test("aprÃ¨s l'import de plusieurs produits, chaque article conserve sa quantitÃ
     ])
   );
 });
+
+test('removeProduct supprime le produit du catalogue et du stock de tous les magasins', async () => {
+  localStorage.clear();
+  localStorage.setItem('pos_current_store', 'wend-kuuni');
+
+  let addProductFn, removeProductFn, setStockForStoreFn, getCatalog, getStock;
+  const Collector = () => {
+    const { addProduct, removeProduct, setStockForStore, productCatalog, stockByStore } = useApp();
+    addProductFn = addProduct;
+    removeProductFn = removeProduct;
+    setStockForStoreFn = setStockForStore;
+    getCatalog = () => productCatalog;
+    getStock = () => stockByStore;
+    return null;
+  };
+
+  render(
+    <AppProvider>
+      <Collector />
+    </AppProvider>
+  );
+
+  await act(async () => {
+    addProductFn({ id: 1, name: 'Produit 1' }, 5);
+    setStockForStoreFn('wend-yam', { 1: 3 });
+  });
+
+  act(() => {
+    removeProductFn(1);
+  });
+
+  expect(getCatalog().find(p => p.id === 1)).toBeUndefined();
+  expect(getStock()['wend-kuuni']?.[1]).toBeUndefined();
+  expect(getStock()['wend-yam']?.[1]).toBeUndefined();
+});

--- a/src/modules/inventory/InventoryModule.jsx
+++ b/src/modules/inventory/InventoryModule.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   Package, AlertTriangle, TrendingDown, TrendingUp,
   Search, Plus, Minus, Edit, Save, X, Bell,
-  BarChart3, Truck, Clock, Eye, RefreshCw
+  BarChart3, Truck, Clock, Eye, RefreshCw, Trash
 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext'; // ✅ Correction critique
 import BarcodeSystem from './BarcodeSystem';
@@ -13,7 +13,7 @@ import ProductImportModal from './ProductImportModal';
 import StockMovements from './StockMovements';
 
 const InventoryModule = () => {
-  const { globalProducts, addStock, appSettings, salesHistory, currentStoreId, addProduct } = useApp();
+  const { globalProducts, addStock, appSettings, salesHistory, currentStoreId, addProduct, removeProduct } = useApp();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [showAddModal, setShowAddModal] = useState(false);
@@ -642,6 +642,29 @@ const InventoryModule = () => {
                           >
                             <Edit size={12} />
                             Modifier
+                          </button>
+
+                          <button
+                            onClick={() => {
+                              if (window.confirm('Supprimer ce produit ?')) {
+                                removeProduct(product.id);
+                              }
+                            }}
+                            style={{
+                              padding: '6px 12px',
+                              background: '#dc2626',
+                              color: 'white',
+                              border: 'none',
+                              borderRadius: '4px',
+                              cursor: 'pointer',
+                              fontSize: '12px',
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: '4px'
+                            }}
+                          >
+                            <Trash size={12} />
+                            Supprimer
                           </button>
                         </div>
                       </td>


### PR DESCRIPTION
## Summary
- add removeProduct to AppContext to drop product from catalog and all store stocks
- wire inventory product list with remove button and confirmation
- test that removing a product clears catalog and per-store stock

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb56f01e60832d882fa5d7d081ad1d