### PR TITLE
feat: support SKU in product imports

### DIFF
--- a/src/modules/inventory/ProductImportModal.test.js
+++ b/src/modules/inventory/ProductImportModal.test.js
@@ -5,11 +5,18 @@ import ProductImportModal from './ProductImportModal';
 
 const mockAddProduct = jest.fn();
 const mockAddStock = jest.fn();
+const mockSetStockForStore = jest.fn();
+
+let mockProductCatalog = [];
+let mockStockByStore = {};
 
 jest.mock('../../contexts/AppContext', () => ({
   useApp: () => ({
     addProduct: mockAddProduct,
     addStock: mockAddStock,
+    setStockForStore: mockSetStockForStore,
+    productCatalog: mockProductCatalog,
+    stockByStore: mockStockByStore,
     appSettings: { darkMode: false },
     stores: [
       { id: 'wend-kuuni', code: 'WK001', name: 'Wend-Kuuni' },
@@ -23,13 +30,16 @@ describe('ProductImportModal', () => {
   beforeEach(() => {
     mockAddProduct.mockClear();
     mockAddStock.mockClear();
+    mockSetStockForStore.mockClear();
+    mockProductCatalog = [];
+    mockStockByStore = {};
   });
 
   test('imports stocks for multiple stores', async () => {
-    const headers = ['name','category','price','costPrice','minStock','stock_WK001','stock_WY002'];
+    const headers = ['sku','name','category','price','costPrice','minStock','stock_WK001','stock_WY002'];
     const data = [
       headers,
-      ['Produit A','Cat','100','50','5','10','20']
+      ['SKU001','Produit A','Cat','100','50','5','10','20']
     ];
     const ws = XLSX.utils.aoa_to_sheet(data);
     const wb = XLSX.utils.book_new();
@@ -52,5 +62,42 @@ describe('ProductImportModal', () => {
     await waitFor(() => expect(mockAddProduct).toHaveBeenCalledTimes(1));
     expect(mockAddProduct.mock.calls[0][1]).toBe(10);
     expect(mockAddStock).toHaveBeenCalledWith('wend-yam', expect.any(Number), 20, 'Import initial');
+  });
+
+  test('updates stock for existing product with same SKU', async () => {
+    mockProductCatalog = [{ id: 1, sku: 'SKU001', name: 'Produit A' }];
+    mockStockByStore = {
+      'wend-kuuni': { 1: 0 },
+      'wend-yam': { 1: 0 }
+    };
+
+    const headers = ['sku','name','category','price','costPrice','minStock','stock_WK001','stock_WY002'];
+    const data = [
+      headers,
+      ['SKU001','Produit A','Cat','100','50','5','7','9']
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(data);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Produits');
+    const binary = XLSX.write(wb, { bookType: 'xlsx', type: 'binary' });
+
+    global.FileReader = class {
+      constructor() { this.onload = null; }
+      readAsBinaryString() { this.onload({ target: { result: binary } }); }
+    };
+
+    const file = new Blob(['']);
+    file.name = 'import.xlsx';
+
+    const { container, getByText } = render(<ProductImportModal isOpen={true} onClose={() => {}} />);
+    const input = container.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(getByText('Importer'));
+
+    await waitFor(() => expect(mockSetStockForStore).toHaveBeenCalledTimes(2));
+    expect(mockAddProduct).not.toHaveBeenCalled();
+    expect(mockAddStock).not.toHaveBeenCalled();
+    expect(mockSetStockForStore).toHaveBeenCalledWith('wend-kuuni', { 1: 7 });
+    expect(mockSetStockForStore).toHaveBeenCalledWith('wend-yam', { 1: 9 });
   });
 });

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,1 @@
+export const generateSku = () => `SKU${Date.now().toString(36)}`;


### PR DESCRIPTION
## Summary
- allow SKU to be provided during product imports and template generation
- update inventory on existing products by SKU when importing
- add SKU generator helper and tests for SKU import logic

## Testing
- `npm test src/modules/inventory/ProductImportModal.test.js` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5abef470832d93674c25b79355cd