### PR TITLE
feat(pos): add numpad toggle state

### DIFF
--- a/src/modules/pos/POSModule.jsx
+++ b/src/modules/pos/POSModule.jsx
@@ -65,6 +65,7 @@ const POSModule = ({ onNavigate }) => {
   const [showClosingPanel, setShowClosingPanel] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
+  const [useNumpad, setUseNumpad] = useState(false);
 
   const isDark = appSettings?.darkMode || false;
 


### PR DESCRIPTION
## Summary
- add local `useNumpad` state to POS module to toggle the cash payment numpad
- rely on the new state for numpad button, input read-only, and conditional keypad rendering

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module './PhysicalInventory', label query errors, and JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5924d9ce8832dbf37f865637094a8