### PR TITLE
feat(printer): agent local Windows pour impression depuis serveur dis…

### DIFF
--- a/components/ReceiptPrinter.js
+++ b/components/ReceiptPrinter.js
@@ -362,14 +362,18 @@ export default function ReceiptPrinter({ sale, onClose, autoPrint = false }) {
     };
   }, [sale, settings, paperWidth]);
 
-  // ── Impression ESC/POS via API Windows (mode 'windows' — WritePrinter) ───
+  // ── Impression ESC/POS via agent local (mode 'windows') ──────────────────
+  // L'agent (printer-agent/index.js) tourne sur le PC de caisse Windows et
+  // écoute sur http://127.0.0.1:6543. Le serveur Next.js peut être distant.
+  const AGENT_URL = 'http://127.0.0.1:6543';
+
   const printViaWindowsESCPOS = useCallback(async (alsoOpenDrawer = true) => {
     try {
       setPortStatus('idle');
-      setStatusMsg('Envoi ESC/POS à l\'imprimante Windows…');
+      setStatusMsg('Envoi ESC/POS à l\'agent local…');
       const printerName = localStorage.getItem('printer_windows_name') || 'POS58';
       const bytes = buildESCPOS(sale, settings, cols, alsoOpenDrawer);
-      const resp = await fetch('/api/printer/print-escpos', {
+      const resp = await fetch(`${AGENT_URL}/print`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ printerName, bytes }),
@@ -387,7 +391,7 @@ export default function ReceiptPrinter({ sale, onClose, autoPrint = false }) {
       }
     } catch (err) {
       setPortStatus('error');
-      setStatusMsg(`Erreur impression: ${err.message}`);
+      setStatusMsg(`Agent introuvable — démarrez printer-agent/start.bat sur ce PC (${err.message})`);
       console.error('[print-escpos]', err);
       return false;
     }
@@ -418,13 +422,18 @@ export default function ReceiptPrinter({ sale, onClose, autoPrint = false }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoPrint]);
 
-  // ── Tiroir-caisse via API serveur (mode dialogue / LPT1 / Windows printer) ─
+  // ── Tiroir-caisse via agent local (mode 'windows') ou API serveur (autres) ─
   const openDrawerViaAPI = useCallback(async () => {
     try {
       setPortStatus('idle');
       setStatusMsg('Ouverture du tiroir…');
       const printerName = localStorage.getItem('printer_windows_name') || 'POS58';
-      const resp = await fetch('/api/printer/open-drawer', {
+      // Mode 'windows' : appel à l'agent local sur ce PC
+      // Autres modes : appel à la route serveur (utile si serveur sur Windows)
+      const url = printMode === 'windows'
+        ? `${AGENT_URL}/drawer`
+        : '/api/printer/open-drawer';
+      const resp = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ printerName }),
@@ -436,14 +445,16 @@ export default function ReceiptPrinter({ sale, onClose, autoPrint = false }) {
       } else {
         setPortStatus('error');
         setStatusMsg(`Erreur tiroir: ${data.error || 'inconnue'}`);
-        console.error('[tiroir API]', data.error);
+        console.error('[tiroir]', data.error);
       }
     } catch (err) {
       setPortStatus('error');
-      setStatusMsg(`Erreur tiroir: ${err.message}`);
-      console.error('[tiroir API]', err);
+      setStatusMsg(printMode === 'windows'
+        ? `Agent introuvable — démarrez printer-agent/start.bat sur ce PC`
+        : `Erreur tiroir: ${err.message}`);
+      console.error('[tiroir]', err);
     }
-  }, []);
+  }, [printMode]);
 
   // ── Tiroir-caisse seul (port série si disponible, sinon API serveur) ───────
   const openCashDrawer = async () => {

--- a/printer-agent/index.js
+++ b/printer-agent/index.js
@@ -1,0 +1,191 @@
+/**
+ * Agent local d'impression POS — printer-agent/index.js
+ *
+ * Tourne sur le PC de caisse Windows.
+ * Écoute sur http://127.0.0.1:6543 (localhost uniquement — non accessible
+ * depuis le réseau extérieur).
+ *
+ * Le navigateur (sur le même PC) appelle directement cet agent pour imprimer
+ * et ouvrir le tiroir, même si le serveur Next.js est distant (Linux/cloud).
+ *
+ * Routes :
+ *   GET  /status          → { ok, platform, version }
+ *   POST /print           → { printerName?, bytes[] }  → ticket ESC/POS
+ *   POST /drawer          → { printerName? }           → ouverture tiroir
+ *
+ * Usage :
+ *   node index.js
+ *   node index.js --port 6543 --printer "POS58"
+ */
+
+'use strict';
+
+const http       = require('http');
+const { execSync }              = require('child_process');
+const { writeFileSync, unlinkSync } = require('fs');
+const { join }   = require('path');
+const { tmpdir } = require('os');
+
+// ── Configuration ────────────────────────────────────────────────────────────
+const args        = process.argv.slice(2);
+const PORT        = parseInt(args[args.indexOf('--port')   + 1] || '6543', 10);
+const DEF_PRINTER = args[args.indexOf('--printer') + 1]  || 'POS58';
+const VERSION     = '1.0.0';
+
+// ── Génération du script PowerShell WritePrinter ──────────────────────────────
+function buildPS1(printerName, bytes, docName) {
+  return `
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public class RawPrint {
+    [DllImport("winspool.drv", CharSet=CharSet.Ansi)]
+    public static extern bool OpenPrinterA(string name, out IntPtr handle, IntPtr pd);
+    [DllImport("winspool.drv")]
+    public static extern bool ClosePrinter(IntPtr handle);
+    [DllImport("winspool.drv", CharSet=CharSet.Ansi)]
+    public static extern int StartDocPrinterA(IntPtr handle, int level, ref DOCINFOA di);
+    [DllImport("winspool.drv")]
+    public static extern bool EndDocPrinter(IntPtr handle);
+    [DllImport("winspool.drv")]
+    public static extern bool StartPagePrinter(IntPtr handle);
+    [DllImport("winspool.drv")]
+    public static extern bool EndPagePrinter(IntPtr handle);
+    [DllImport("winspool.drv")]
+    public static extern bool WritePrinter(IntPtr handle, IntPtr pBytes, int count, out int written);
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
+    public struct DOCINFOA {
+        public int cbSize;
+        public string pDocName;
+        public string pOutputFile;
+        public string pDataType;
+    }
+}
+'@
+$h = [IntPtr]::Zero
+$ok = [RawPrint]::OpenPrinterA("${printerName}", [ref]$h, [IntPtr]::Zero)
+if (-not $ok) { Write-Error "Impossible d'ouvrir : ${printerName}"; exit 1 }
+$doc = New-Object RawPrint+DOCINFOA
+$doc.cbSize    = [System.Runtime.InteropServices.Marshal]::SizeOf($doc)
+$doc.pDocName  = "${docName}"
+$doc.pDataType = "RAW"
+[RawPrint]::StartDocPrinterA($h, 1, [ref]$doc) | Out-Null
+[RawPrint]::StartPagePrinter($h) | Out-Null
+$bytes = [byte[]](${bytes.join(',')})
+$ptr = [System.Runtime.InteropServices.Marshal]::AllocHGlobal($bytes.Length)
+[System.Runtime.InteropServices.Marshal]::Copy($bytes, 0, $ptr, $bytes.Length)
+$w = 0
+[RawPrint]::WritePrinter($h, $ptr, $bytes.Length, [ref]$w) | Out-Null
+[System.Runtime.InteropServices.Marshal]::FreeHGlobal($ptr)
+[RawPrint]::EndPagePrinter($h)  | Out-Null
+[RawPrint]::EndDocPrinter($h)   | Out-Null
+[RawPrint]::ClosePrinter($h)    | Out-Null
+Write-Output "sent:$w"
+`;
+}
+
+function runPS1(psContent, prefix) {
+  const file = join(tmpdir(), `${prefix}_${Date.now()}.ps1`);
+  writeFileSync(file, psContent, 'utf8');
+  try {
+    return execSync(
+      `powershell.exe -NonInteractive -ExecutionPolicy Bypass -File "${file}"`,
+      { timeout: 15000, encoding: 'utf8' }
+    ).trim();
+  } finally {
+    try { unlinkSync(file); } catch { /* ignore */ }
+  }
+}
+
+// ── Helpers HTTP ──────────────────────────────────────────────────────────────
+function json(res, status, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin':  '*',   // localhost uniquement par bind
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(body);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try { resolve(JSON.parse(body || '{}')); }
+      catch (e) { reject(e); }
+    });
+    req.on('error', reject);
+  });
+}
+
+// ── Serveur ───────────────────────────────────────────────────────────────────
+const server = http.createServer(async (req, res) => {
+  // Preflight CORS
+  if (req.method === 'OPTIONS') { json(res, 204, {}); return; }
+
+  // GET /status
+  if (req.method === 'GET' && req.url === '/status') {
+    json(res, 200, { ok: true, platform: process.platform, version: VERSION, printer: DEF_PRINTER });
+    return;
+  }
+
+  // POST /drawer
+  if (req.method === 'POST' && req.url === '/drawer') {
+    try {
+      const body        = await readBody(req);
+      const printerName = (body.printerName || DEF_PRINTER).replace(/[^a-zA-Z0-9 _\-().]/g, '');
+      const drawerBytes = [27, 112, 0, 25, 250, 27, 112, 1, 25, 250]; // pin2 + pin5
+      const result      = runPS1(buildPS1(printerName, drawerBytes, 'CashDrawer'), 'drawer');
+      console.log(`[tiroir] ${printerName} → ${result}`);
+      json(res, 200, { ok: true, result });
+    } catch (err) {
+      console.error('[tiroir]', err.message);
+      json(res, 500, { ok: false, error: err.stderr?.toString() || err.message });
+    }
+    return;
+  }
+
+  // POST /print
+  if (req.method === 'POST' && req.url === '/print') {
+    try {
+      const body        = await readBody(req);
+      const printerName = (body.printerName || DEF_PRINTER).replace(/[^a-zA-Z0-9 _\-().]/g, '');
+      const bytes       = body.bytes;
+      if (!Array.isArray(bytes) || bytes.length === 0)
+        return json(res, 400, { ok: false, error: 'bytes[] requis' });
+      if (!bytes.every(b => Number.isInteger(b) && b >= 0 && b <= 255))
+        return json(res, 400, { ok: false, error: 'bytes[] : valeurs 0-255 uniquement' });
+      const result = runPS1(buildPS1(printerName, bytes, 'Receipt'), 'receipt');
+      console.log(`[print]  ${printerName} → ${result}`);
+      json(res, 200, { ok: true, result });
+    } catch (err) {
+      console.error('[print]', err.message);
+      json(res, 500, { ok: false, error: err.stderr?.toString() || err.message });
+    }
+    return;
+  }
+
+  json(res, 404, { error: 'Route inconnue' });
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log('╔══════════════════════════════════════════════════╗');
+  console.log(`║  Agent imprimante POS  v${VERSION}                   ║`);
+  console.log(`║  http://127.0.0.1:${PORT}  (localhost uniquement)  ║`);
+  console.log(`║  Imprimante par défaut : ${DEF_PRINTER.padEnd(24)}║`);
+  console.log('╚══════════════════════════════════════════════════╝');
+  console.log('En attente de commandes... (Ctrl+C pour arrêter)\n');
+});
+
+server.on('error', err => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`\n❌ Le port ${PORT} est déjà utilisé.`);
+    console.error('   Un autre agent tourne peut-être déjà. Vérifiez le Gestionnaire de tâches.');
+  } else {
+    console.error('Erreur serveur:', err.message);
+  }
+  process.exit(1);
+});

--- a/printer-agent/install-autostart.bat
+++ b/printer-agent/install-autostart.bat
@@ -1,0 +1,23 @@
+@echo off
+:: Ajoute l'agent dans le dossier Démarrage de Windows
+:: (se lance automatiquement à chaque ouverture de session)
+
+set STARTUP=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup
+set SCRIPT=%~dp0start.bat
+
+echo Copie dans le dossier Demarrage Windows...
+copy "%SCRIPT%" "%STARTUP%\agent-imprimante-pos.bat" >nul
+
+if %errorlevel%==0 (
+    echo.
+    echo  OK - L'agent demarrera automatiquement au prochain login.
+    echo  Fichier installe dans :
+    echo  %STARTUP%\agent-imprimante-pos.bat
+) else (
+    echo.
+    echo  ERREUR - Impossible de copier le fichier.
+    echo  Copiez manuellement start.bat dans :
+    echo  %STARTUP%
+)
+echo.
+pause

--- a/printer-agent/start.bat
+++ b/printer-agent/start.bat
@@ -1,0 +1,6 @@
+@echo off
+title Agent Imprimante POS
+cd /d "%~dp0"
+echo Demarrage de l'agent imprimante...
+node index.js --printer "POS58"
+pause


### PR DESCRIPTION
…tant

- printer-agent/index.js : mini-serveur HTTP Node.js (localhost:6543) qui tourne sur le PC de caisse Windows. Routes : GET  /status  → état de l'agent
    POST /print   → ticket ESC/POS complet via WritePrinter
    POST /drawer  → ouverture tiroir via WritePrinter
  Utilise powershell.exe + tmpdir() natif Windows — aucune dépendance npm

- printer-agent/start.bat : lancement simple (double-clic)
- printer-agent/install-autostart.bat : démarrage automatique au login

- ReceiptPrinter.js : mode 'windows' appelle maintenant l'agent local (http://127.0.0.1:6543) au lieu des routes /api/printer/* du serveur → le serveur Next.js peut être distant (Linux/cloud), l'impression reste locale sur le PC de caisse Windows

https://claude.ai/code/session_01P2YbLVHzGWuTLUJKFgMZVN